### PR TITLE
Enable to pass screenProps

### DIFF
--- a/src/FluidTransitioner.js
+++ b/src/FluidTransitioner.js
@@ -162,7 +162,10 @@ class FluidTransitioner extends React.Component<*> {
         route={scene.route.routeName}
         sceneKey={scene.key}
       >
-        <Scene navigation={navigation} />
+        <Scene
+          navigation={navigation}
+          screenProps={this.props.screenProps}
+        />
       </TransitionRouteView>
     );
   }


### PR DESCRIPTION
Thanks for the great library.
 
I use screenProps in StackNavigator, but react-navigation-fluid-transitions seems not to support screenProps yet. So I add support screenProps in this pull request.

This works well for me, like the code bellow.
```
const Stack = FluidNavigator(
  {
    Home: {
      screen: SearchScreen,
    }
}
class SearchScreen extends React.Component {
  render() {
    const { navigate } = this.props.navigation;
    console.log(this.props.screenProps)
    ....
 }
}
//usage:
//<Stack
//    screenProps="foo"
///>
```

Thanks.