### PR TITLE
Added call to forceupdate for all transition items before transition

### DIFF
--- a/src/TransitionItems.js
+++ b/src/TransitionItems.js
@@ -30,6 +30,9 @@ export default class TransitionItems {
     return false;
   }
 
+  getItems() {
+    return this._items;
+  }
   getRoutes() {
     const routes = [];
     for (let i = 0; i < this._items.length; i++) {

--- a/src/TransitionItemsView.js
+++ b/src/TransitionItemsView.js
@@ -221,6 +221,9 @@ export default class TransitionItemsView extends React.Component<
       await this._interactionDonePromise;
       await this.measureItems(sharedElements, transitionElements);
 
+      // Update visibility style based on calculation by re-rendering all transition elements.
+      this._transitionItems.getItems().forEach(item => item.reactElement.forceUpdate());
+
       if (!sharedElements.find(p => !p.fromItem.metrics || !p.toItem.metrics) &&
         !transitionElements.find(i => !i.metrics)) {
         // HACK: Setting state in componentDidUpdate is not nice - but

--- a/src/TransitionView.js
+++ b/src/TransitionView.js
@@ -99,7 +99,7 @@ class Transition extends React.Component<TransitionProps> {
 
     const visibilityStyle = this.getVisibilityStyle();    
     const key = `${this._getName()}-${this._route}`;
-
+    
     element = React.createElement(element.type, { ...element.props, key, ref: this.setViewRef });
     return createAnimatedWrapper({
       component: element,
@@ -108,7 +108,7 @@ class Transition extends React.Component<TransitionProps> {
       cached: this._animatedComponent,
       log: true,
       logPrefix: "TV " + this._getName() + "/" + this._route
-    });      
+    });
   }
   
   setViewRef = (ref: any) => {


### PR DESCRIPTION
The reason for this is to ensure that visibility is correctly recalcuated based on the current properties for the transition state.