### PR TITLE
Move prop-types to dep. + fix lodash imports

### DIFF
--- a/Examples/src/ImageTransition.js
+++ b/Examples/src/ImageTransition.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { View, Text, Dimensions, Button, TouchableOpacity, FlatList, Image, StyleSheet } from 'react-native';
-import _ from 'lodash';
+import chunk from 'lodash.chunk';
 import { StackNavigator } from 'react-navigation';
 import { FluidNavigator, Transition } from 'react-navigation-fluid-transitions';
 
@@ -117,7 +117,7 @@ class ImageGrid extends Component {
     const { width: windowWidth } = Dimensions.get('window');
     this._margin = 2;
     this._photoSize = (windowWidth - this._margin * this._colCount * 2) / this._colCount;
-    this.state = { chunkedImages: _.chunk(props.images, this._colCount) };
+    this.state = { chunkedImages: chunk(props.images, this._colCount) };
   }
 
   _colCount
@@ -126,7 +126,7 @@ class ImageGrid extends Component {
   _chunkedImages
 
   componentWillReceiveProps(nextProps) {
-    this.setState({ ...this.state, chunkedImages: _.chunk(nextProps.images, this._colCount) });
+    this.setState({ ...this.state, chunkedImages: chunk(nextProps.images, this._colCount) });
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,12 @@
     "url": "https://github.com/fram-x/FluidTransitions/issues"
   },
   "homepage": "https://github.com/fram-x/FluidTransitions#readme",
+  "dependencies": {
+    "lodash.sortby": "*",
+    "lodash.chunk": "*",
+    "prop-types": "*"
+  },
   "peerDependencies": {
-    "lodash": "*",
-    "prop-types": "*",
     "react": "*",
     "react-native": "*",
     "react-navigation": "*"

--- a/src/TransitionOverlayView.js
+++ b/src/TransitionOverlayView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleSheet, Animated } from 'react-native';
 import PropTypes from 'prop-types';
-import * as _ from 'lodash'
+import sortBy from 'lodash.sortBy'
 
 import TransitionItem from './TransitionItem';
 import { NavigationDirection, TransitionContext, RouteDirection } from './Types';
@@ -58,7 +58,7 @@ class TransitionOverlayView extends React.Component<Props> {
     const anchoredViews = getAnchoredElements(sharedElements, this.getInterpolation);
 
     let views = [...transitionViews, ...sharedElementViews, ...anchoredViews];
-    views = _.sortBy(views, 'props.index');    
+    views = sortBy(views, 'props.index');    
     
     return (
       <Animated.View style={[styles.overlay, this.getVisibilityStyle()]} pointerEvents="none">


### PR DESCRIPTION
This PR moves `prop-types` from peerDependencies to dependencies, this is the [recommended](https://github.com/facebook/prop-types#how-to-depend-on-this-package) practice. Also, there is no need to import all lodash's utilities, I added the ones the package is depending on to the dependencies as well.