### PR TITLE
Propagates stackConfig.style to FluidTransitioner

### DIFF
--- a/src/FluidNavigator.js
+++ b/src/FluidNavigator.js
@@ -33,6 +33,7 @@ export default (routeConfigMap, stackConfig = {}) => {
       return (
         <FluidTransitioner
           mode={mode}
+          style={style}
           navigation={this.props.navigation}
           descriptors={this.props.descriptors}
           onTransitionStart={this.props.onTransitionStart}


### PR DESCRIPTION
I was chasing down an issue where the initial rendering of my `FluidNavigator` was briefly grey before being white (the color my first view had). Eventually I tracked it down to being the `FluidTransitioner` and fixed by issue by passing it in props.

Given that https://github.com/fram-x/FluidTransitions/blob/develop/src/FluidTransitioner.js#L207 already supports being given style props, and `stackConfig` already expected a style (although it did nothing with it) I've added what I believe was originally intended: to propagate the style to the transitioner.