### PR TITLE
Added check to avoid waiting when no transitions are waiting

### DIFF
--- a/src/TransitionItemsView.js
+++ b/src/TransitionItemsView.js
@@ -320,7 +320,15 @@ export default class TransitionItemsView extends React.Component<
   componentDidMount() {
     this._isMounted = true;
     this.updateFromProps({ ...this.props, index: -1 });
-    InteractionManager.runAfterInteractions(this._interactionDonePromiseDone);
+    // check for transition elements - we don't need to wait for transitions
+    // if we dont have any appearing elements
+    const te = this._transitionItems.getTransitionElements(this.props.fromRoute, this.props.toRoute);
+    if(te.length > 0){
+      InteractionManager.runAfterInteractions(this._interactionDonePromiseDone);
+    }
+    else {
+      this._interactionDonePromiseDone();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
- When starting a new screen there might be some appear transitions we need to play. I added a test to see if there are any, if not, we can start immediately showing the UI.

Fixes #44 