### PR TITLE
Fixed issue with error in shallowrenderer on RN 0.56

### DIFF
--- a/src/TransitionItem.js
+++ b/src/TransitionItem.js
@@ -13,7 +13,7 @@ export default class TransitionItem {
   constructor(
     name: string, route: string, reactElement: Object,
     shared: boolean, appear: string, disappear: string,
-    delay: boolean, index: number, anchor: string, animated: string
+    delay: boolean, index: number, anchor: string, animated: string,
   ) {
     this.name = name;
     this.route = route;
@@ -24,7 +24,7 @@ export default class TransitionItem {
     this.delay = delay;
     this.index = index;
     this.anchor = anchor;
-    this.animated = animated
+    this.animated = animated;
   }
 
   name: string
@@ -54,25 +54,27 @@ export default class TransitionItem {
 
   getFlattenedStyle(refresh = false) {
     if (refresh || !this.flattenedStyle) {
-      const element = React.Children.only(this.reactElement.props.children);      
+      const element = React.Children.only(this.reactElement.props.children);
       if (!element) { return null; }
-      
+
       // Shallow renderer should not need to be used for views we know does
       // not create any magic inner styles. The following test is needed
       // when running in production mode.
-      const shouldRenderRenderElement = element.type !== 'RCTView';
-      let style = element.props.style;
+      const shouldRenderRenderElement = element.type !== 'RCTView' &&
+        element.type && element.type.displayName !== 'View';
 
-      if(shouldRenderRenderElement) {
-        if (!this._testRenderer) { 
-          this._testRenderer = ShallowRenderer.createRenderer()        
-        } 
-        const tree = this._testRenderer.render(element);      
-        style = tree.props.style;        
-      } 
-    
-      if (!style) return null;      
-      this.flattenedStyle = StyleSheet.flatten(style);      
+      let { style } = element.props;
+
+      if (shouldRenderRenderElement) {
+        if (!this._testRenderer) {
+          this._testRenderer = ShallowRenderer.createRenderer();
+        }
+        const tree = this._testRenderer.render(element);
+        style = tree.props.style;
+      }
+
+      if (!style) return null;
+      this.flattenedStyle = StyleSheet.flatten(style);
     }
 
     return this.flattenedStyle;
@@ -98,18 +100,17 @@ export default class TransitionItem {
         height: r.height,
       };
 
-      this.boundingBoxMetrics = getBoundingBox({ rect: this.metrics, theta: t});
-
+      this.boundingBoxMetrics = getBoundingBox({ rect: this.metrics, theta: t });
     } else {
       this.metrics = { x: x - viewMetrics.x, y: y - viewMetrics.y, width, height };
       this.boundingBoxMetrics = this.metrics;
-    }    
+    }
 
     // console.log(this.name  + "/" + this.route + "-" + this.metrics.x + "," + this.metrics.y + " - " + this.metrics.width + "," + this.metrics.height);
   }
 
   getRotation() {
-    if(!this._rotation) {
+    if (!this._rotation) {
       const ri = getRotationFromStyle(this.getFlattenedStyle());
       let retVal = { type: 'unknown', value: 0 };
       if (ri.rotate) {
@@ -139,18 +140,18 @@ export default class TransitionItem {
       x: this.metrics.width / other.metrics.width,
       y: this.metrics.height / other.metrics.height,
     };
-  }  
+  }
 }
 
 const getRotationRad = (ri) => {
   if (ri.type === 'deg') return getDegreesToRadians(ri.value);
   return ri.value;
-}
+};
 
 const getRotationDeg = (ri) => {
   if (ri.type === 'rad') return getRadiansToDegrees(ri.value);
   return ri.value;
-}
+};
 
 const getDegreesToRadians = (degrees: number): number => degrees * Math.PI / 180;
 const getRadiansToDegrees = (rad: number): number => rad * 180 / Math.PI;


### PR DESCRIPTION
In React Native 0.56 we see an error described here: #54.

This PR fixes this issue by testing for views when deciding wether or not to use shallow rendering to retrieve styles.