### PR TITLE
Update shallowRenderer.js

### DIFF
--- a/src/Utils/shallowRenderer.js
+++ b/src/Utils/shallowRenderer.js
@@ -65,7 +65,11 @@ class ShallowRenderer {
         }
         this._mountClassComponent(element.props, context);
       } else {
-        this._rendered = element.type(element.props, context);
+        if (typeof element.type == 'function') {
+          this._rendered = element.type(element.props, context); 
+        } else {
+          this._rendered = element.type.render(element.props, context);
+        }
       }
     }
 

--- a/src/Utils/shallowRenderer.js
+++ b/src/Utils/shallowRenderer.js
@@ -65,7 +65,7 @@ class ShallowRenderer {
         }
         this._mountClassComponent(element.props, context);
       } else {
-        if (typeof element.type == 'function') {
+        if (typeof element.type === 'function') {
           this._rendered = element.type(element.props, context); 
         } else {
           this._rendered = element.type.render(element.props, context);


### PR DESCRIPTION
Fixes element.type is not a function error in RN 0.56. https://github.com/fram-x/FluidTransitions/issues/54