### PR TITLE
Fixed navigating to other screens than the first route

### DIFF
--- a/lib/TransitionItemsView.js
+++ b/lib/TransitionItemsView.js
@@ -77,6 +77,8 @@ export default class TransitionItemsView extends React.Component<
 
   _interactionDonePromiseDone: Function;
 
+  _shouldRunStartAnimation: boolean = true;
+
   componentWillReceiveProps(nextProps) {
     this.updateFromProps(nextProps, this.props);
   }
@@ -291,9 +293,7 @@ export default class TransitionItemsView extends React.Component<
         }), () => {
           const { onLayout } = this.props;
           if (onLayout) onLayout();
-          if (fromRoute === null) {
-            this._runStartAnimation(transitionElements.length);
-          }
+          this._runStartAnimation(transitionElements.length);
           this._inUpdate = false;
         });
       }
@@ -304,8 +304,16 @@ export default class TransitionItemsView extends React.Component<
   }
 
   async _runStartAnimation(numberOfTransitions: number) {
+    if (!this._shouldRunStartAnimation) { return; }
+
+    this._shouldRunStartAnimation = false;
     const { getTransitionConfig } = this.context;
-    const { toRoute, navigation } = this.props;
+    const { toRoute, navigation, index } = this.props;
+
+    if (index > 0) {
+      this._transitionProgress.setValue(index - 1);
+    }
+
     const transitionSpec = getTransitionConfig
       ? getTransitionConfig(toRoute, navigation) : {
         timing: Animated.timing,
@@ -317,12 +325,11 @@ export default class TransitionItemsView extends React.Component<
 
     const { timing } = transitionSpec;
     delete transitionSpec.timing;
-
     const animations = [
       timing(this._transitionProgress, {
         ...transitionSpec,
         duration: numberOfTransitions === 0 ? 25 : transitionSpec.duration,
-        toValue: 0,
+        toValue: index,
       }),
     ];
 


### PR DESCRIPTION
The problem is that the startup animation which reveals the user interface is not run for other than the first route. Fixes #77.