### PR TITLE
Support different aspect ratio in shared element transitions

### DIFF
--- a/Examples/ImageTransition.js
+++ b/Examples/ImageTransition.js
@@ -9,7 +9,7 @@ const styles = StyleSheet.create({
   },
   detailsImage: {
     width: Dimensions.get('window').width,
-    height: Dimensions.get('window').width,
+    height: Dimensions.get('window').width * 0.5,
   },
   detailsView: {
     padding: 10,
@@ -83,7 +83,8 @@ class ImageListScreen extends React.Component {
 
 class ImageDetailsScreen extends React.Component {
   render() {
-    const uri = this.props.navigation.getParam('url', '');
+    const { navigation } = this.props;
+    const uri = navigation.getParam('url', '');
     return (
       <View style={styles.container}>
         <Transition anchor={uri}>
@@ -100,7 +101,7 @@ class ImageDetailsScreen extends React.Component {
           <View style={styles.detailsView}>
             <Text style={styles.text}>{uri}</Text>
             <View style={styles.buttonContainer}>
-              <Button title="Back" onPress={() => this.props.navigation.goBack()} />
+              <Button title="Back" onPress={() => navigation.goBack()} />
             </View>
           </View>
         </Transition>

--- a/Examples/LayoutTransition.js
+++ b/Examples/LayoutTransition.js
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
   },
   smallImage: {
     width: (Dimensions.get('window').width - 45) * 0.5,
-    height: ((Dimensions.get('window').width - 45) * 0.5) * 0.5,
+    height: (Dimensions.get('window').width - 45) * 0.5,
   },
   imageContainer: {
     flexDirection: 'row',

--- a/lib/Interpolators/getPositionInterpolator.js
+++ b/lib/Interpolators/getPositionInterpolator.js
@@ -3,22 +3,38 @@ import { InterpolatorSpecification } from '../Types/InterpolatorSpecification';
 
 export const getPositionInterpolator = (spec: InterpolatorSpecification): StyleSheet.Styles => {
   const nativeInterpolator = spec.getInterpolation(true);
+  if (spec.equalAspectRatio) {
   // Create Native interpolation
+    const translateX = nativeInterpolator.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, (spec.to.metrics.x - spec.from.metrics.x)
+      + spec.from.metrics.width / 2 * (spec.scaleX - 1)],
+    });
+
+    const translateY = nativeInterpolator.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, (spec.to.metrics.y - spec.from.metrics.y)
+      + spec.from.metrics.height / 2 * (spec.scaleY - 1)],
+    });
+
+    return { nativeAnimationStyles: {
+      width: spec.from.metrics.width,
+      height: spec.from.metrics.height,
+      transform: [{ translateX }, { translateY }] },
+    };
+  }
+
   const translateX = nativeInterpolator.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, (spec.to.metrics.x - spec.from.metrics.x)
-      + spec.from.metrics.width / 2 * (spec.scaleX - 1)],
+    outputRange: [0, (spec.to.metrics.x - spec.from.metrics.x)],
   });
 
   const translateY = nativeInterpolator.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, (spec.to.metrics.y - spec.from.metrics.y)
-      + spec.from.metrics.height / 2 * (spec.scaleY - 1)],
+    outputRange: [0, (spec.to.metrics.y - spec.from.metrics.y)],
   });
 
   return { nativeAnimationStyles: {
-    width: spec.from.metrics.width,
-    height: spec.from.metrics.height,
     transform: [{ translateX }, { translateY }] },
   };
 };

--- a/lib/Interpolators/getScaleInterpolator.js
+++ b/lib/Interpolators/getScaleInterpolator.js
@@ -2,17 +2,29 @@ import { StyleSheet } from 'react-native';
 import { InterpolatorSpecification } from '../Types/InterpolatorSpecification';
 
 export const getScaleInterpolator = (spec: InterpolatorSpecification): StyleSheet.Styles => {
-  const interpolator = spec.getInterpolation(true);
+  if (spec.equalAspectRatio) {
+    const interpolator = spec.getInterpolation(true);
 
-  const scaleX = interpolator.interpolate({
+    const scaleX = interpolator.interpolate({
+      inputRange: [0, 1],
+      outputRange: [1, spec.scaleX],
+    });
+
+    const scaleY = interpolator.interpolate({
+      inputRange: [0, 1],
+      outputRange: [1, spec.scaleY],
+    });
+
+    return { nativeAnimationStyles: { transform: [{ scaleX }, { scaleY }] } };
+  }
+  const interpolator = spec.getInterpolation(false);
+  const width = interpolator.interpolate({
     inputRange: [0, 1],
-    outputRange: [1, spec.scaleX],
+    outputRange: [spec.from.metrics.width, spec.to.metrics.width],
   });
-
-  const scaleY = interpolator.interpolate({
+  const height = interpolator.interpolate({
     inputRange: [0, 1],
-    outputRange: [1, spec.scaleY],
+    outputRange: [spec.from.metrics.height, spec.to.metrics.height],
   });
-
-  return { nativeAnimationStyles: { transform: [{ scaleX }, { scaleY }] } };
+  return { animationStyles: { width, height } };
 };

--- a/lib/Interpolators/getSharedElements.js
+++ b/lib/Interpolators/getSharedElements.js
@@ -11,15 +11,17 @@ const getSharedElements = (sharedElements: Array<any>,
   getInterpolationFunction: Function) => sharedElements.map((pair, idx) => {
   const { fromItem, toItem } = pair;
   const element = React.Children.only(fromItem.reactElement.props.children);
-  const transitionStyles = getTransitionStyle(fromItem, toItem, getInterpolationFunction);
+
+  const equalAspectRatio = getIsEqualAspectRatio(fromItem, toItem);
+
+  const transitionStyles = getTransitionStyle(fromItem, toItem, getInterpolationFunction,
+    equalAspectRatio);
 
   const key = `so-${idx.toString()}`;
   const animationStyle = transitionStyles.styles;
   const nativeAnimationStyle = [transitionStyles.nativeStyles];
   const overrideStyles = {
     position: 'absolute',
-    // borderColor: '#0000FF',
-    // borderWidth: 1,
     left: fromItem.metrics.x,
     top: fromItem.metrics.y,
     width: fromItem.metrics.width,
@@ -38,13 +40,21 @@ const getSharedElements = (sharedElements: Array<any>,
     nativeStyles: nativeAnimationStyle,
     styles: animationStyle,
     overrideStyles,
+    equalAspectRatio,
     log: true,
     logPrefix: `SE: ${fromItem.name}/${fromItem.route}`,
   });
 });
 
+const getIsEqualAspectRatio = (fromItem, toItem) => {
+  const fromAspect = Math.round((fromItem.metrics.width / fromItem.metrics.height) * 100) / 100;
+  const toAspect = Math.round((toItem.metrics.width / toItem.metrics.height) * 100) / 100;
+  return fromAspect === toAspect;
+};
+
 const getTransitionStyle = (
   fromItem: TransitionItem, toItem: TransitionItem, getInterpolationFunction: Function,
+  equalAspectRatio: boolean,
 ) => {
   const interpolatorInfo: InterpolatorSpecification = {
     from: {
@@ -59,6 +69,7 @@ const getTransitionStyle = (
     },
     scaleX: toItem.scaleRelativeTo(fromItem).x,
     scaleY: toItem.scaleRelativeTo(fromItem).y,
+    equalAspectRatio,
     getInterpolation: getInterpolationFunction,
     dimensions: Dimensions.get('window'),
   };

--- a/lib/Interpolators/getStyleInterpolator.js
+++ b/lib/Interpolators/getStyleInterpolator.js
@@ -19,8 +19,8 @@ export const getStyleInterpolator = (
   if (fromValue === toValue) return null;
 
   // Handle scaling of numeric values
-  const parsed = parseInt(toValue);
-  if (!isNaN(parsed)) {
+  const parsed = parseInt(toValue, 10);
+  if (!Number.isNaN(parsed)) {
     toValue = parsed / spec.scaleX;
   }
 

--- a/lib/TransitionItem.js
+++ b/lib/TransitionItem.js
@@ -85,7 +85,7 @@ export default class TransitionItem {
           this._testRenderer = ShallowRenderer.createRenderer();
         }
         const tree = this._testRenderer.render(element);
-        style = tree.props.style;
+        style = tree.props.style ? tree.props.style : style;
       }
 
       if (!style) return null;

--- a/lib/Types/InterpolatorSpecification.js
+++ b/lib/Types/InterpolatorSpecification.js
@@ -14,5 +14,6 @@ export type InterpolatorSpecification = {
   scaleX: number,
   scaleY: number,
   dimensions: any,
+  equalAspectRatio: boolean,
   getInterpolation: (useNativeDriver: Boolean) => any,
 }

--- a/lib/Utils/createAnimatedWrapper.js
+++ b/lib/Utils/createAnimatedWrapper.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { View, Animated, Platform, StyleSheet } from 'react-native';
+import { View, Animated, StyleSheet } from 'react-native';
 
 import { getRotationFromStyle } from './getRotationFromStyle';
-
+import { mergeStyles } from './mergeStyles';
 /*
   This HOC wrapper creates animatable wrappers around the provided component
   to make it animatable - independent of wether it is a stateless or class
@@ -48,10 +48,13 @@ type Parameters = {
   overrideStyles: ?StyleSheet.NamedStyles,
   nativeCached: ?any,
   cached: ?any,
+  equalAspectRatio: ?boolean,
   log: ?Boolean,
   logPrefix: ?string
 }
 const createAnimatedWrapper = (params: Parameters) => {
+  const equalAspectRatio = params.equalAspectRatio === undefined ? true : params.equalAspectRatio;
+
   // Create wrapped views
   const nativeAnimatedComponent = params.nativeCached || createAnimated();
   const animatedComponent = params.cached || createAnimated();
@@ -62,12 +65,13 @@ const createAnimatedWrapper = (params: Parameters) => {
   // Get styles
   const nativeAnimatedStyles = getNativeAnimatableStyles(flattenedStyle);
   const animatedStyles = getAnimatableStyles(flattenedStyle);
-  const componentStyles = getComponentStyles(flattenedStyle);
+  const componentStyles = getResolvedAspectRatio(equalAspectRatio, true,
+    getComponentStyles(flattenedStyle));
 
   // create inner element
   const innerElement = React.createElement(params.component.type, {
     ...params.component.props,
-    style: [componentStyles, getDebugBorder('#FF0')],
+    style: [componentStyles, getDebugBorder('#F00')],
   });
 
   // Check if we have an absolute positioned element
@@ -106,11 +110,13 @@ const createAnimatedWrapper = (params: Parameters) => {
 
   let props = {
     collapsable: false, // Used to fix measure on Android
-    style: finalNativeAnimatedStyles,
+    style: getResolvedAspectRatio(equalAspectRatio, false, finalNativeAnimatedStyles),
   };
 
   // Copy some key properties
-  if (params.component.props.__index) { props = { ...props, index: parseInt(params.component.props.__index) }; }
+  if (params.component.props.__index) {
+    props = { ...props, index: parseInt(params.component.props.__index, 10) };
+  }
   if (params.component.key) { props = { ...props, key: params.component.key }; }
   if (params.component.ref) { props = { ...props, ref: params.component.ref }; }
   if (params.component.onLayout) { props = { ...props, onLayout: params.component.onLayout }; }
@@ -145,7 +151,20 @@ const createAnimated = () => {
   return Animated.createAnimatedComponent(wrapper.type);
 };
 
-const getDebugBorder = (/* color: string*/) => ({}); // ({ borderWidth: 1, borderColor: color});
+const getDebugBorder = () => ({}); // (color: string) => ({ borderWidth: 1, borderColor: color });
+
+const getResolvedAspectRatio = (equalAspectRatio: boolean,
+  addFlex: boolean, style: StyleSheet.Style | Array<StyleSheet.Style>) => {
+  if (!style || equalAspectRatio) return style;
+  const retVal = !(style instanceof Array) ? [{ ...style }] : style.map(s => ({ ...s }));
+  retVal.forEach(r => {
+    // remove height/width and replace with flex: 1
+    delete r.width;
+    delete r.height;
+  });
+  if (!addFlex) return retVal;
+  return [...retVal, { flex: 1 }];
+};
 
 const getResolvedRotation = (styles: Array<StyleSheet.Styles>) => {
   // if(Platform.OS === 'ios') return styles;
@@ -160,7 +179,6 @@ const getResolvedRotation = (styles: Array<StyleSheet.Styles>) => {
     return sc;
   });
   const a = new Animated.Value(0);
-  const retVal = [];
   stylesCopy.forEach(style => {
     if (style && style.transform) {
       const ri = getRotationFromStyle(style);
@@ -186,7 +204,9 @@ const getResolvedRotation = (styles: Array<StyleSheet.Styles>) => {
   return stylesCopy;
 };
 
-const getStylesWithMergedTransforms = (styles: Array<StyleSheet.NamedStyles>): Array<StyleSheet.NamedStyles> => {
+const getStylesWithMergedTransforms = (
+  styles: Array<StyleSheet.NamedStyles>,
+): Array<StyleSheet.NamedStyles> => {
   const retVal = [];
   const transforms = [];
   if (styles) {
@@ -209,11 +229,18 @@ const getStylesWithMergedTransforms = (styles: Array<StyleSheet.NamedStyles>): A
   return styles;
 };
 
-const getNativeAnimatableStyles = (styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles) => getFilteredStyle(styles, (key) => includePropsForNativeStyles.indexOf(key) > -1);
+const getNativeAnimatableStyles = (
+  styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+) => getFilteredStyle(styles, (key) => includePropsForNativeStyles.indexOf(key) > -1);
 
-const getAnimatableStyles = (styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles) => getFilteredStyle(styles, (key) => validStyles.indexOf(key) > -1 && excludePropsForStyles.indexOf(key) === -1);
+const getAnimatableStyles = (
+  styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+) => getFilteredStyle(styles, (key) => validStyles.indexOf(key) > -1
+&& excludePropsForStyles.indexOf(key) === -1);
 
-const getComponentStyles = (styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles) => getFilteredStyle(styles, (key) => excludePropsForComponent.indexOf(key) === -1);
+const getComponentStyles = (
+  styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+) => getFilteredStyle(styles, (key) => excludePropsForComponent.indexOf(key) === -1);
 
 const getFilteredStyle = (
   styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
@@ -245,7 +272,7 @@ const getFilteredStyle = (
   return retVal;
 };
 
-function isNumber(n) { return !isNaN(parseFloat(n)) && !isNaN(n - 0); }
+function isNumber(n) { return !Number.isNaN(parseFloat(n)) && !Number.isNaN(n - 0); }
 
 const paddingStyles = [
   'padding',

--- a/lib/Utils/getRotationFromStyle.js
+++ b/lib/Utils/getRotationFromStyle.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-function isNumber(n) { return !isNaN(parseFloat(n)) && !isNaN(n - 0); }
+function isNumber(n) { return !Number.isNaN(parseFloat(n)) && !Number.isNaN(n - 0); }
 
 const getRotationFromStyle = (style) => {
   if (!style) return {};

--- a/lib/Utils/mergeStyles.js
+++ b/lib/Utils/mergeStyles.js
@@ -22,6 +22,6 @@ const mergeStyles = (styles: Array<any>): StyleSheet.Styles => {
   return retVal;
 };
 
-function isNumber(n) { return !isNaN(parseFloat(n)) && !isNaN(n - 0); }
+function isNumber(n) { return !Number.isNaN(parseFloat(n)) && !Number.isNaN(n - 0); }
 
 export { mergeStyles };


### PR DESCRIPTION
Components in the from/to route are not necessary having the same aspect ratios. This could potentially be a problem with components like images where you would see some strange scaling issue and a jump at the end of the transition.

This PR detects wether or not the to/from components have the same aspect ratio, and if not it uses size to interpolate between the two instead of transform.

The backside of this PR is that size is only animatable through the non-native driver, so you might notice a slight degradation in performance when applying shared element transitions between elements with different aspect ratios.