### PR TITLE
Added support for Animated components as Transition elements.

### DIFF
--- a/lib/TransitionItem.js
+++ b/lib/TransitionItem.js
@@ -84,8 +84,12 @@ export default class TransitionItem {
         if (!this._testRenderer) {
           this._testRenderer = ShallowRenderer.createRenderer();
         }
-        const tree = this._testRenderer.render(element);
-        style = tree.props.style;
+        try {
+          const tree = this._testRenderer.render(element);
+          style = tree.props.style ? tree.props.style : style;
+        } catch (err) {
+          // Ignore
+        }
       }
 
       if (!style) return null;


### PR DESCRIPTION
The error was caused by the `shallowRenderer` trying to render an animated component. Added a try...catch since we already have the basic style.