### PR TITLE
Shared Element fontSize and color Interpolation

### DIFF
--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -40,17 +40,14 @@ const styles = StyleSheet.create({
   text1: {
     fontSize: 12,
     color: 'black',
-    backgroundColor: 'aqua',
   },
   text2: {
     fontSize: 24,
-    color: 'red',
-    backgroundColor: 'yellow',
+    color: '#EE0000',
   },
   text3: {
     fontSize: 12,
-    color: 'green',
-    backgroundColor: 'aqua',
+    color: '#55AA55',
   },
 });
 

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Text, Animated, Button, StyleSheet } from 'react-native';
 import { Transition, createFluidNavigator } from '../lib';
 
 const styles = StyleSheet.create({
@@ -39,12 +39,18 @@ const styles = StyleSheet.create({
   },
   text1: {
     fontSize: 12,
+    color: 'black',
+    backgroundColor: 'aqua',
   },
   text2: {
-    fontSize: 18,
+    fontSize: 24,
+    color: 'red',
+    backgroundColor: 'yellow',
   },
   text3: {
-    fontSize: 14,
+    fontSize: 12,
+    color: 'green',
+    backgroundColor: 'aqua',
   },
 });
 
@@ -75,8 +81,9 @@ const Shape = ({ background, size, borderRadius }) => (
 const Screen1 = (props) => (
   <View style={styles.container}>
     <Transition shared="text">
-      <Text style={styles.text1}>Welcome!</Text>
+      <Text style={styles.text1}>Fluid Transitions</Text>
     </Transition>
+    <Animated.Text></Animated.Text>
     <View style={styles.screen1}>
       <Transition shared="circle">
         <Shape size={50} borderRadius={4} background="#EE0000" />
@@ -106,7 +113,7 @@ const Screen1 = (props) => (
 const Screen2 = (props) => (
   <View style={styles.container}>
     <Transition shared="text">
-      <Text style={styles.text2}>Welcome!</Text>
+      <Text style={styles.text2}>Fluid Transitions</Text>
     </Transition>
     <View style={styles.screen2}>
       <Transition shared="circle">
@@ -139,7 +146,7 @@ const Screen2 = (props) => (
 const Screen3 = (props) => (
   <View style={styles.container}>
     <Transition shared="text">
-      <Text style={styles.text3}>Welcome!</Text>
+      <Text style={styles.text3}>Fluid Transitions</Text>
     </Transition>
     <View style={styles.screen3}>
       <Transition shared="circle">

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -37,36 +37,45 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     padding: 20,
   },
+  text1: {
+    fontSize: 12,
+  },
+  text2: {
+    fontSize: 18,
+  },
+  text3: {
+    fontSize: 14,
+  },
 });
 
-const Circle = (props) => (
+const Circle = ({ background, size }) => (
   <View
     style={{
       justifyContent: 'center',
       alignItems: 'center',
-      backgroundColor: props.background,
-      width: props.size,
-      height: props.size,
-      borderRadius: props.size / 2,
+      backgroundColor: background,
+      width: size,
+      height: size,
+      borderRadius: size / 2,
     }}
   />
 );
 
-const Shape = (props) => (
+const Shape = ({ background, size, borderRadius }) => (
   <View
     style={{
-      backgroundColor: props.background || '#EE0000',
-      width: props.size,
-      height: props.size,
-      borderRadius: props.borderRadius || 0,
+      backgroundColor: background || '#EE0000',
+      width: size,
+      height: size,
+      borderRadius: borderRadius || 0,
     }}
   />
 );
 
 const Screen1 = (props) => (
   <View style={styles.container}>
-    <Transition appear="flip">
-      <Text>1.Screen</Text>
+    <Transition shared="text">
+      <Text style={styles.text1}>Welcome!</Text>
     </Transition>
     <View style={styles.screen1}>
       <Transition shared="circle">
@@ -96,8 +105,8 @@ const Screen1 = (props) => (
 
 const Screen2 = (props) => (
   <View style={styles.container}>
-    <Transition appear="flip">
-      <Text>2.Screen</Text>
+    <Transition shared="text">
+      <Text style={styles.text2}>Welcome!</Text>
     </Transition>
     <View style={styles.screen2}>
       <Transition shared="circle">
@@ -129,8 +138,8 @@ const Screen2 = (props) => (
 
 const Screen3 = (props) => (
   <View style={styles.container}>
-    <Transition appear="flip">
-      <Text>3.Screen</Text>
+    <Transition shared="text">
+      <Text style={styles.text3}>Welcome!</Text>
     </Transition>
     <View style={styles.screen3}>
       <Transition shared="circle">

--- a/lib/Interpolators/InterpolatorTypes.js
+++ b/lib/Interpolators/InterpolatorTypes.js
@@ -1,8 +1,11 @@
+import { InterpolatorSpecification } from '../Types/InterpolatorSpecification';
+import { InterpolatorResult } from '../Types/InterpolatorResult';
 import { getPositionInterpolator } from './getPositionInterpolator';
 import { getScaleInterpolator } from './getScaleInterpolator';
 import { getRotationInterpolator } from './getRotationInterpolator';
 import { getBorderInterpolator } from './getBorderInterpolator';
 import { getBackgroundInterpolator } from './getBackgroundInterpolator';
+import { getTextInterpolator } from './getTextInterpolator';
 
 type InterpolatorEntry = {
   name: string,
@@ -23,8 +26,9 @@ export function initInterpolatorTypes() {
   registerInterpolator('position', getPositionInterpolator);
   registerInterpolator('scale', getScaleInterpolator);
   registerInterpolator('rotation', getRotationInterpolator);
+  registerInterpolator('text', getTextInterpolator);
 }
 
-export function getInterpolatorTypes() : InterpolatorEntry {
+export function getInterpolatorTypes() : Array<InterpolatorEntry> {
   return interpolators;
 }

--- a/lib/Interpolators/getStyleInterpolator.js
+++ b/lib/Interpolators/getStyleInterpolator.js
@@ -11,7 +11,7 @@ export const getStyleInterpolator = (
   const toStyle = spec.to.style;
 
   if ((!fromStyle || !fromStyle[key])
-    && (!toStyle || !toStyle[key])) return null;
+    && (!toStyle || !toStyle[key])) return null;
 
   const fromValue = fromStyle && fromStyle[key] ? fromStyle[key] : defaultValue;
   let toValue = toStyle && toStyle[key] ? toStyle[key] : defaultValue;
@@ -21,7 +21,11 @@ export const getStyleInterpolator = (
   // Handle scaling of numeric values
   const parsed = parseInt(toValue, 10);
   if (!Number.isNaN(parsed)) {
-    toValue = parsed / spec.scaleX;
+    if (spec.equalAspectRatio) {
+      toValue = parsed / spec.scaleX;
+    } else {
+      toValue = parsed;
+    }
   }
 
   const interpolator = (spec.getInterpolation(useNative))

--- a/lib/Interpolators/getTextInterpolator.js
+++ b/lib/Interpolators/getTextInterpolator.js
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native';
+import { InterpolatorSpecification } from '../Types/InterpolatorSpecification';
+import { getStyleInterpolator } from './getStyleInterpolator';
+
+export const getTextInterpolator = (spec: InterpolatorSpecification): StyleSheet.Styles => {
+  const fontSize = getStyleInterpolator('fontSize', null, false, spec);
+  // const fontWeight = getStyleInterpolator('fontWeight', null, false, spec, false);
+  // const fontFamily = getStyleInterpolator('fontFamily', null, false, spec);
+  const color = getStyleInterpolator('color', null, false, spec);
+  return { animationStyles: { fontSize, /* fontWeight, fontFamily, */ color } };
+};

--- a/lib/Utils/createAnimatedWrapper.js
+++ b/lib/Utils/createAnimatedWrapper.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, Animated, StyleSheet } from 'react-native';
 
 import { getRotationFromStyle } from './getRotationFromStyle';
-import { mergeStyles } from './mergeStyles';
 /*
   This HOC wrapper creates animatable wrappers around the provided component
   to make it animatable - independent of wether it is a stateless or class
@@ -69,10 +68,25 @@ const createAnimatedWrapper = (params: Parameters) => {
     getComponentStyles(flattenedStyle));
 
   // create inner element
-  const innerElement = React.createElement(params.component.type, {
+  let innerElement = React.createElement(params.component.type, {
     ...params.component.props,
     style: [componentStyles, getDebugBorder('#F00')],
   });
+
+  if (getIsTextWithAnimatedStyles(params)) {
+    const animatedTextStyles = getAnimatedTextStyles(params.styles);
+    const resultingStyles = getFilteredStyle(componentStyles,
+      (key) => textStyles.indexOf(key) === -1);
+
+    innerElement = React.createElement(Animated.Text, {
+      ...params.component.props,
+      style: [animatedTextStyles, resultingStyles],
+    });
+    delete params.overrideStyles.width;
+    delete params.overrideStyles.height;
+    delete params.styles.width;
+    delete params.styles.height;
+  }
 
   // Check if we have an absolute positioned element
   const additionalAnimatedStyles = { overflow: 'hidden' };
@@ -152,6 +166,16 @@ const createAnimated = () => {
 };
 
 const getDebugBorder = () => ({}); // (color: string) => ({ borderWidth: 1, borderColor: color });
+
+const getIsTextWithAnimatedStyles = (params: Parameters): boolean => {
+  if (params.styles && params.component.type && params.component.type.displayName === 'Text') {
+    // Check if we have text interpolation (fontSize, weight, fontFamily, color)
+    if (Object.keys(params.styles).filter(key => textStyles.indexOf(key) > -1)) {
+      return true;
+    }
+  }
+  return false;
+};
 
 const getResolvedAspectRatio = (equalAspectRatio: boolean,
   addFlex: boolean, style: StyleSheet.Style | Array<StyleSheet.Style>) => {
@@ -241,6 +265,10 @@ const getAnimatableStyles = (
 const getComponentStyles = (
   styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
 ) => getFilteredStyle(styles, (key) => excludePropsForComponent.indexOf(key) === -1);
+
+const getAnimatedTextStyles = (
+  styles:Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+) => getFilteredStyle(styles, (key) => textStyles.indexOf(key) > -1);
 
 const getFilteredStyle = (
   styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
@@ -359,6 +387,7 @@ const excludePropsForComponent = [
   'translateY',
   'backfaceVisibility',
   'backgroundColor',
+  ...textStyles,
 ];
 
 const includePropsForNativeStyles = [
@@ -451,6 +480,12 @@ const validStyles = [
   'backgroundColor',
   'opacity',
   'elevation',
+  ...textStyles,
+];
+
+const textStyles = [
+  'fontSize',
+  'color',
 ];
 
 export { createAnimatedWrapper, createAnimated };

--- a/lib/Utils/createAnimatedWrapper.js
+++ b/lib/Utils/createAnimatedWrapper.js
@@ -42,51 +42,23 @@ import { getRotationFromStyle } from './getRotationFromStyle';
 */
 type Parameters = {
   component: any,
-  nativeStyles: ?StyleSheet.NamedStyles,
-  styles: ?StyleSheet.NamedStyles,
-  overrideStyles: ?StyleSheet.NamedStyles,
+  nativeStyles: ?StyleSheet.Styles,
+  styles: ?StyleSheet.Styles,
+  overrideStyles: ?StyleSheet.Styles,
   nativeCached: ?any,
   cached: ?any,
   equalAspectRatio: ?boolean,
   log: ?Boolean,
   logPrefix: ?string
 }
+
 const createAnimatedWrapper = (params: Parameters) => {
-  const equalAspectRatio = params.equalAspectRatio === undefined ? true : params.equalAspectRatio;
+  const paramsCopy = { ...params };
 
-  // Create wrapped views
-  const nativeAnimatedComponent = params.nativeCached || createAnimated();
-  const animatedComponent = params.cached || createAnimated();
-
-  // Flatten style
-  const flattenedStyle = StyleSheet.flatten(params.component.props.style);
-
-  // Get styles
-  const nativeAnimatedStyles = getNativeAnimatableStyles(flattenedStyle);
-  const animatedStyles = getAnimatableStyles(flattenedStyle);
-  const componentStyles = getResolvedAspectRatio(equalAspectRatio, true,
-    getComponentStyles(flattenedStyle));
-
-  // create inner element
-  let innerElement = React.createElement(params.component.type, {
-    ...params.component.props,
-    style: [componentStyles, getDebugBorder('#F00')],
-  });
-
-  if (getIsTextWithAnimatedStyles(params)) {
-    const animatedTextStyles = getAnimatedTextStyles(params.styles);
-    const resultingStyles = getFilteredStyle(componentStyles,
-      (key) => textStyles.indexOf(key) === -1);
-
-    innerElement = React.createElement(Animated.Text, {
-      ...params.component.props,
-      style: [animatedTextStyles, resultingStyles],
-    });
-    delete params.overrideStyles.width;
-    delete params.overrideStyles.height;
-    delete params.styles.width;
-    delete params.styles.height;
-  }
+  // Get values from parameters
+  const equalAspectRatio = getEqualAspectRatio(paramsCopy);
+  const { nativeAnimatedComponent, animatedComponent } = getAnimatedComponents(paramsCopy);
+  const { nativeAnimatedStyles, animatedStyles, componentStyles } = getStylesFromParams(paramsCopy);
 
   // Check if we have an absolute positioned element
   const additionalAnimatedStyles = { overflow: 'hidden' };
@@ -98,27 +70,61 @@ const createAnimatedWrapper = (params: Parameters) => {
     additionalAnimatedStyles.flex = 1;
   }
 
-  // Create Animated element
-  const finalAnimatedStyles = [
-    animatedStyles,
-    params.styles,
-    additionalAnimatedStyles,
-    getDebugBorder('#0F0'),
-  ];
+  const shouldRenderAnimatedStyles = !paramsCopy.styles && animatedStyles;
 
-  const animatedElement = React.createElement(
-    animatedComponent, { style: finalAnimatedStyles },
-    innerElement,
-  );
+  // create inner element
+  const innerElementProps = { ...paramsCopy.component.props };
+  let innerElement = React.createElement(paramsCopy.component.type, {
+    ...innerElementProps,
+    style: [
+      componentStyles,
+      shouldRenderAnimatedStyles ? animatedStyles : {},
+      shouldRenderAnimatedStyles ? additionalAnimatedStyles : {},
+      getDebugBorder('#F00'),
+    ],
+  });
+
+  if (getIsTextWithAnimatedStyles(paramsCopy)) {
+    const animatedTextStyles = getAnimatedTextStyles(paramsCopy.styles);
+    const resultingStyles = getFilteredStyle(componentStyles,
+      (key) => textStyles.indexOf(key) === -1);
+
+    innerElement = React.createElement(Animated.Text, {
+      ...paramsCopy.component.props,
+      adjustsFontSizeToFit: true,
+      style: [animatedTextStyles, resultingStyles],
+    });
+
+    delete paramsCopy.overrideStyles.width;
+    delete paramsCopy.overrideStyles.height;
+    delete paramsCopy.styles.width;
+    delete paramsCopy.styles.height;
+  }
+
+  let animatedElement = innerElement;
+  if (paramsCopy.styles) {
+    // Create Animated element
+    const finalAnimatedStyles = [
+      animatedStyles,
+      paramsCopy.styles,
+      additionalAnimatedStyles,
+      getDebugBorder('#0F0'),
+    ];
+
+    animatedElement = React.createElement(
+      animatedComponent, { style: finalAnimatedStyles },
+      innerElement,
+    );
+  }
 
   // Setup props for the outer wrapper (and native animated component)
   const finalNativeAnimatedStyles = getResolvedRotation(
     [...getStylesWithMergedTransforms([
-      ...(params.nativeStyles ? params.nativeStyles : []),
+      ...(paramsCopy.nativeStyles ? paramsCopy.nativeStyles : []),
       nativeAnimatedStyles,
     ]),
     getDebugBorder('#00F'),
-    params.overrideStyles,
+    paramsCopy.overrideStyles,
     ],
   );
 
@@ -143,21 +149,25 @@ const createAnimatedWrapper = (params: Parameters) => {
   );
 
   // if (__DEV__) {
-  //   if(params.log) {
-  //     const log = (params.logPrefix ? params.logPrefix + "\n" : "") +
-  //       "  innerElement:          " + JSON.stringify(StyleSheet.flatten(innerElement.props.style)) + "\n" +
-  //       "  animatedElement:       " + JSON.stringify(StyleSheet.flatten(animatedElement.props.style)) + "\n" +
-  //       "  nativeAnimatedElement: " + JSON.stringify(StyleSheet.flatten(nativeAnimatedElement.props.style));
-  //     if(lastLog !== log){
+  //   if (params.log) {
+  //     const log = `${params.logPrefix ? `${params.logPrefix}\n` : ''
+  //     }  innerElement:          ${
+  //       JSON.stringify(StyleSheet.flatten(innerElement.props.style))}\n${
+  //       innerElement !== animatedElement ? `  animatedElement:       ${
+  //         JSON.stringify(StyleSheet.flatten(animatedElement.props.style))}\n` : ''
+  //     }  nativeAnimatedElement: ${
+  //       JSON.stringify(StyleSheet.flatten(nativeAnimatedElement.props.style))}`;
+  //     if (lastLog !== log) {
   //       lastLog = log;
-  //       console.log("\n" + log + "\n");
+  //       console.log(`\n${log}\n`);
   //     }
   //   }
   // }
 
   return nativeAnimatedElement;
 };
-// const lastLog = '';
+
+// let lastLog = '';
 
 const createAnimated = () => {
   // Create wrapped view
@@ -228,9 +238,33 @@ const getResolvedRotation = (styles: Array<StyleSheet.Styles>) => {
   return stylesCopy;
 };
 
+const getEqualAspectRatio = (params: Parameters) => (
+  params.equalAspectRatio === undefined ? true : params.equalAspectRatio);
+
+const getAnimatedComponents = (params: Parameters) => (
+  {
+    nativeAnimatedComponent: params.nativeCached || createAnimated(),
+    animatedComponent: params.cached || createAnimated(),
+  }
+);
+
+const getStylesFromParams = (params: Parameters) => {
+  const flattenedStyle = StyleSheet.flatten(params.component.props.style);
+
+  // Get styles
+  const nativeAnimatedStyles = getNativeAnimatableStyles(flattenedStyle);
+  const animatedStyles = getAnimatableStyles(flattenedStyle);
+  const componentStyles = getResolvedAspectRatio(
+    getEqualAspectRatio(params), true, getComponentStyles(flattenedStyle),
+  );
+  return {
+    nativeAnimatedStyles, animatedStyles, componentStyles,
+  };
+};
+
 const getStylesWithMergedTransforms = (
-  styles: Array<StyleSheet.NamedStyles>,
-): Array<StyleSheet.NamedStyles> => {
+  styles: Array<StyleSheet.Styles>,
+): Array<StyleSheet.Styles> => {
   const retVal = [];
   const transforms = [];
   if (styles) {
@@ -254,24 +288,24 @@ const getStylesWithMergedTransforms = (
 };
 
 const getNativeAnimatableStyles = (
-  styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+  styles: Array<StyleSheet.Styles>|StyleSheet.Styles,
 ) => getFilteredStyle(styles, (key) => includePropsForNativeStyles.indexOf(key) > -1);
 
 const getAnimatableStyles = (
-  styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+  styles: Array<StyleSheet.Styles>|StyleSheet.Styles,
 ) => getFilteredStyle(styles, (key) => validStyles.indexOf(key) > -1
 && excludePropsForStyles.indexOf(key) === -1);
 
 const getComponentStyles = (
-  styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+  styles: Array<StyleSheet.Styles>|StyleSheet.Styles,
 ) => getFilteredStyle(styles, (key) => excludePropsForComponent.indexOf(key) === -1);
 
 const getAnimatedTextStyles = (
-  styles:Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+  styles:Array<StyleSheet.Styles>|StyleSheet.Styles,
 ) => getFilteredStyle(styles, (key) => textStyles.indexOf(key) > -1);
 
 const getFilteredStyle = (
-  styles: Array<StyleSheet.NamedStyles>|StyleSheet.NamedStyles,
+  styles: Array<StyleSheet.Styles>|StyleSheet.Styles,
   shouldIncludeKey: (key: String) => void,
 ) => {
   if (!styles) return styles;


### PR DESCRIPTION
Based on a few feature requests (issue #30, #100), interpolating text is important. After investigating some of the issue related to this, I have created this pull request.

It adds support for animating `color` and `fontSize` (`fontFamily`, `fontWeight` was not as easy as I first thought) for text. 

**Limitation**: only one liners allowed, still having some issues with text breaking over multiple lines.

This PR requires PR #98.