### PR TITLE
Support Nested Transitions

### DIFF
--- a/Examples/Onboarding.js
+++ b/Examples/Onboarding.js
@@ -42,21 +42,21 @@ const styles = StyleSheet.create({
   },
 });
 
-const Circle = (props) => (
+const Circle = ({ background, size }) => (
   <View style={{
-    backgroundColor: props.background,
-    width: props.size,
-    height: props.size,
-    borderRadius: props.size / 2,
+    backgroundColor: background,
+    width: size,
+    height: size,
+    borderRadius: size / 2,
     margin: 14 }}
   />
 );
 
-const Square = (props) => (
+const Square = ({ background, size }) => (
   <View style={{
-    backgroundColor: props.background,
-    width: props.size,
-    height: props.size,
+    backgroundColor: background,
+    width: size,
+    height: size,
     margin: 14 }}
   />
 );

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
   },
   buttons: {
     flexDirection: 'row',
-    padding: 20,
+    padding: 10,
   },
 });
 

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -163,7 +163,7 @@ const Screen2 = ({ navigation }) => (
         <Transition anchor={`image${navigation.getParam('id')}`}>
           <Text style={styles.bigTitle}>{`Card ${navigation.getParam('id')}`}</Text>
         </Transition>
-        <Transition anchor={`image${navigation.getParam('id')}`}>
+        <Transition appear="horizontal" anchor={`image${navigation.getParam('id')}`}>
           <ScrollView style={styles.commentsContainer}>
             <Text style={styles.comment}>Comment 1</Text>
             <Text style={styles.comment}>Comment 2</Text>
@@ -177,7 +177,10 @@ const Screen2 = ({ navigation }) => (
     </Transition>
     <Transition anchor={`image${navigation.getParam('id')}`}>
       <View style={styles.buttons}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          hitSlop={{ left: 20, top: 20, right: 20, bottom: 20 }}
+        >
           <Icon name="arrow-left" size={24} color="#FFF" />
         </TouchableOpacity>
       </View>

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -105,8 +105,8 @@ class Screen1 extends React.Component {
   }
 
   componentWillMount() {
-    const items = getRandomImages(20, Dimensions.get('window').width);
-    const users = getRandomImages(20, 30).map(img => ({
+    const items = getRandomImages(5, Dimensions.get('window').width);
+    const users = getRandomImages(5, 30).map(img => ({
       source: img,
       name: 'User name',
     }));

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -1,37 +1,30 @@
 import React from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Text, TouchableOpacity, Button, StyleSheet } from 'react-native';
+import { withNavigation } from 'react-navigation';
 import { Transition, createFluidNavigator } from '../lib';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  card: {
+    backgroundColor: '#ECEEFA',
+    margin: 20,
+    marginTop: 10,
+    marginBottom: 10,
+    padding: 20,
+    borderColor: '#AAA',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    shadowOpacity: 0.5,
+    shadowColor: '#AAA',
+    shadowOffset: { width: 2, height: 5 },
+  },
+  bigCard: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: '#FFF',
     justifyContent: 'center',
     alignItems: 'center',
-    padding: 20,
-  },
-  screen1: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    justifyContent: 'center',
-    alignSelf: 'stretch',
-    padding: 20,
-  },
-  screen2: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    alignSelf: 'stretch',
-    justifyContent: 'center',
-    padding: 20,
-  },
-  screen3: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    alignSelf: 'stretch',
-    justifyContent: 'center',
-    padding: 20,
   },
   buttons: {
     flexDirection: 'row',
@@ -39,89 +32,45 @@ const styles = StyleSheet.create({
   },
 });
 
-const Circle = ({ background, size }) => (
-  <View
-    style={{
-      justifyContent: 'center',
-      alignItems: 'center',
-      backgroundColor: background,
-      width: size,
-      height: size,
-      borderRadius: size / 2,
-    }}
-  />
+const Card = ({ navigation, id }) => (
+  <Transition shared={`card${id}`} top appear="horizontal" delay>
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() => navigation.navigate('screen2', { id })}
+      hitSlop={{ left: 20, top: 20, right: 20, bottom: 20 }}
+    >
+      <Transition shared={`text${id}`}>
+        <Text>{`Card ${id}`}</Text>
+      </Transition>
+    </TouchableOpacity>
+  </Transition>
 );
 
-const Shape = ({ background, size, borderRadius }) => (
-  <View
-    style={{
-      backgroundColor: background || '#EE0000',
-      width: size,
-      height: size,
-      borderRadius: borderRadius || 0,
-    }}
-  />
-);
+const NavCard = withNavigation(Card);
 
 const Screen1 = (props) => (
   <View style={styles.container}>
-    <Transition appear="flip">
-      <Text>1.Screen</Text>
-    </Transition>
-    <View style={styles.screen1}>
-      <Transition shared="circle">
-        <Shape size={50} borderRadius={4} background="#EE0000" />
-      </Transition>
-    </View>
-    <View style={{ flexDirection: 'row' }}>
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-      <View style={{ width: 20 }} />
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-      <View style={{ width: 20 }} />
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-    </View>
-    <Transition appear="horizontal">
-      <View style={styles.buttons}>
-        <Button title="Next" onPress={() => props.navigation.navigate('screen2')} />
-      </View>
-    </Transition>
+    <NavCard id={1} />
+    <NavCard id={2} />
+    <NavCard id={3} />
+    <NavCard id={4} />
   </View>
 );
 
-const Screen2 = (props) => (
+const Screen2 = ({ navigation }) => (
   <View style={styles.container}>
-    <Transition appear="flip">
-      <Text>2.Screen</Text>
+    <Transition shared={`card${navigation.getParam('id')}`}>
+      <View style={styles.bigCard}>
+        <Transition shared={`text${navigation.getParam('id')}`}>
+          <Text>{`Card ${navigation.getParam('id')}`}</Text>
+        </Transition>
+      </View>
     </Transition>
-    <View style={styles.screen2}>
-      <Transition shared="circle">
-        <Shape size={50} borderRadius={25} background="#EE0000" />
-      </Transition>
-    </View>
-    <View style={{ flexDirection: 'row' }}>
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-      <View style={{ width: 20 }} />
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-      <View style={{ width: 20 }} />
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-    </View>
     <Transition appear="horizontal">
       <View style={styles.buttons}>
-        <Button title="Back" onPress={() => props.navigation.goBack()} />
+        <Button title="Back" onPress={() => navigation.goBack()} />
         <View style={{ width: 20 }} />
-        <Button title="Next" onPress={() => props.navigation.navigate('screen3')} />
+        <Button title="Next" onPress={() => navigation.navigate('screen3')} />
       </View>
     </Transition>
   </View>
@@ -129,27 +78,6 @@ const Screen2 = (props) => (
 
 const Screen3 = (props) => (
   <View style={styles.container}>
-    <Transition appear="flip">
-      <Text>3.Screen</Text>
-    </Transition>
-    <View style={styles.screen3}>
-      <Transition shared="circle">
-        <Shape size={140} borderRadius={70} background="#EE0000" />
-      </Transition>
-    </View>
-    <View style={{ flexDirection: 'row' }}>
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-      <View style={{ width: 20 }} />
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-      <View style={{ width: 20 }} />
-      <Transition appear="horizontal" delay>
-        <Circle background="#55AA55" size={20} />
-      </Transition>
-    </View>
     <Transition appear="horizontal">
       <View style={styles.buttons}>
         <Button title="Back" onPress={() => props.navigation.goBack()} />

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -16,9 +16,9 @@ const styles = StyleSheet.create({
     marginTop: 10,
     marginBottom: 10,
     borderRadius: 4,
-    shadowOpacity: 0.5,
+    shadowOpacity: 0.3,
     shadowColor: '#AAA',
-    shadowOffset: { width: 2, height: 5 },
+    shadowOffset: { width: 0, height: 4 },
   },
   smallImage: {
     width: Dimensions.get('window').width - 40,
@@ -105,7 +105,7 @@ class Screen1 extends React.Component {
   }
 
   componentWillMount() {
-    const items = getRandomImages(10, Dimensions.get('window').width);
+    const items = getRandomImages(1, Dimensions.get('window').width);
     const users = getRandomImages(10, 30).map(img => ({
       source: img,
       name: 'User name',
@@ -175,7 +175,13 @@ const Navigator = createFluidNavigator({
   screen1: { screen: Screen1 },
   screen2: { screen: Screen2 },
 }, {
-  navigationOptions: { gesturesEnabled: true },
+  navigationOptions: {
+    gesturesEnabled: true,
+    gestureResponseDistance: {
+      horizontal: Dimensions.get('window').width,
+      vertical: Dimensions.get('window').height,
+    },
+  },
 });
 
 class SharedElements extends React.Component {

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -52,10 +52,13 @@ const styles = StyleSheet.create({
     height: Dimensions.get('window').width,
   },
   bigTitle: {
-    margin: 20,
+    paddingHorizontal: 10,
   },
-  detailsContainer: {
-    padding: 20,
+  commentsContainer: {
+    padding: 10,
+  },
+  comment: {
+    fontSize: 11,
   },
   buttons: {
     flexDirection: 'row',
@@ -68,7 +71,7 @@ const Card = ({ navigation, avatar, imageSource, id }) => (
     <TouchableOpacity
       activeOpacity={0.8}
       style={styles.card}
-      onPress={() => navigation.navigate('screen2', { id, source: imageSource })}
+      onPress={() => navigation.navigate('screen2', { id, source: imageSource, avatar })}
       hitSlop={{ left: 20, top: 20, right: 20, bottom: 20 }}
     >
       <Transition appear="horizontal" disappear="fade">
@@ -89,7 +92,7 @@ const Card = ({ navigation, avatar, imageSource, id }) => (
           <Icon name="paperclip" size={22} />
         </View>
       </Transition>
-      <Transition shared={`text${id}`}>
+      <Transition appear="horizontal" disappear="fade">
         <Text style={styles.smallTitle}>{`Card ${id}`}</Text>
       </Transition>
     </TouchableOpacity>
@@ -151,13 +154,24 @@ const Screen2 = ({ navigation }) => (
         <Transition shared={`image${navigation.getParam('id')}`}>
           <Image style={styles.bigImage} source={navigation.getParam('source')} />
         </Transition>
-        <Transition shared={`text${navigation.getParam('id')}`}>
+        <Transition anchor={`image${navigation.getParam('id')}`}>
+          <View style={styles.imageHeader}>
+            <Image source={navigation.getParam('avatar').source} style={styles.avatarImage} />
+            <Text style={styles.avatarText}>{navigation.getParam('avatar').name}</Text>
+          </View>
+        </Transition>
+        <Transition anchor={`image${navigation.getParam('id')}`}>
           <Text style={styles.bigTitle}>{`Card ${navigation.getParam('id')}`}</Text>
         </Transition>
-        <Transition appear="fade">
-          <View style={styles.detailsContainer}>
-            <Text>Image details</Text>
-          </View>
+        <Transition anchor={`image${navigation.getParam('id')}`}>
+          <ScrollView style={styles.commentsContainer}>
+            <Text style={styles.comment}>Comment 1</Text>
+            <Text style={styles.comment}>Comment 2</Text>
+            <Text style={styles.comment}>Comment 3</Text>
+            <Text style={styles.comment}>Comment 4</Text>
+            <Text style={styles.comment}>Comment 5</Text>
+            <Text style={styles.comment}>Comment 6</Text>
+          </ScrollView>
         </Transition>
       </View>
     </Transition>

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -9,7 +9,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   card: {
-    backgroundColor: '#ECEEFA',
+    backgroundColor: '#FFF',
     flexDirection: 'column',
     justifyContent: 'center',
     margin: 20,
@@ -66,6 +66,23 @@ const styles = StyleSheet.create({
   },
 });
 
+const ImageHeader = () => (
+  <View style={styles.imageHeader}>
+    <Icon name="heart-outline" size={22} />
+    <View style={{ width: 10 }} />
+    <Icon name="comment-outline" size={22} />
+    <View style={{ width: 10 }} />
+    <Icon name="paperclip" size={22} />
+  </View>
+);
+
+const Avatar = ({ avatar }) => (
+  <View style={styles.imageHeader}>
+    <Image source={avatar.source} style={styles.avatarImage} />
+    <Text style={styles.avatarText}>{avatar.name}</Text>
+  </View>
+);
+
 const Card = ({ navigation, avatar, imageSource, id }) => (
   <Transition shared={`card${id}`} top appear="horizontal" disappear="fade">
     <TouchableOpacity
@@ -75,25 +92,13 @@ const Card = ({ navigation, avatar, imageSource, id }) => (
       hitSlop={{ left: 20, top: 20, right: 20, bottom: 20 }}
     >
       <Transition appear="horizontal" disappear="fade">
-        <View style={styles.imageHeader}>
-          <Image source={avatar.source} style={styles.avatarImage} />
-          <Text style={styles.avatarText}>{avatar.name}</Text>
-        </View>
+        <Avatar avatar={avatar} />
       </Transition>
       <Transition shared={`image${id}`}>
         <Image style={styles.smallImage} source={imageSource} />
       </Transition>
-      <Transition appear="horizontal" disappear="fade">
-        <View style={styles.imageHeader}>
-          <Icon name="heart-outline" size={22} />
-          <View style={{ width: 10 }} />
-          <Icon name="comment-outline" size={22} />
-          <View style={{ width: 10 }} />
-          <Icon name="paperclip" size={22} />
-        </View>
-      </Transition>
-      <Transition appear="horizontal" disappear="fade">
-        <Text style={styles.smallTitle}>{`Card ${id}`}</Text>
+      <Transition shared={`imageHeader${id}`}>
+        <ImageHeader />
       </Transition>
     </TouchableOpacity>
   </Transition>
@@ -154,16 +159,13 @@ const Screen2 = ({ navigation }) => (
         <Transition shared={`image${navigation.getParam('id')}`}>
           <Image style={styles.bigImage} source={navigation.getParam('source')} />
         </Transition>
-        <Transition appear="fade">
-          <View style={styles.imageHeader}>
-            <Image source={navigation.getParam('avatar').source} style={styles.avatarImage} />
-            <Text style={styles.avatarText}>{navigation.getParam('avatar').name}</Text>
-          </View>
+        <Transition shared={`imageHeader${navigation.getParam('id')}`}>
+          <ImageHeader />
         </Transition>
-        <Transition appear="fade">
-          <Text style={styles.bigTitle}>{`Card ${navigation.getParam('id')}`}</Text>
+        <Transition anchor={`image${navigation.getParam('id')}`}>
+          <Avatar avatar={navigation.getParam('avatar')} />
         </Transition>
-        <Transition appear="fade">
+        <Transition anchor={`image${navigation.getParam('id')}`}>
           <ScrollView style={styles.commentsContainer}>
             <Text style={styles.comment}>Comment 1</Text>
             <Text style={styles.comment}>Comment 2</Text>

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -105,8 +105,8 @@ class Screen1 extends React.Component {
   }
 
   componentWillMount() {
-    const items = getRandomImages(5, Dimensions.get('window').width);
-    const users = getRandomImages(5, 30).map(img => ({
+    const items = getRandomImages(15, Dimensions.get('window').width);
+    const users = getRandomImages(15, 30).map(img => ({
       source: img,
       name: 'User name',
     }));

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -154,16 +154,16 @@ const Screen2 = ({ navigation }) => (
         <Transition shared={`image${navigation.getParam('id')}`}>
           <Image style={styles.bigImage} source={navigation.getParam('source')} />
         </Transition>
-        <Transition anchor={`image${navigation.getParam('id')}`}>
+        <Transition appear="fade">
           <View style={styles.imageHeader}>
             <Image source={navigation.getParam('avatar').source} style={styles.avatarImage} />
             <Text style={styles.avatarText}>{navigation.getParam('avatar').name}</Text>
           </View>
         </Transition>
-        <Transition anchor={`image${navigation.getParam('id')}`}>
+        <Transition appear="fade">
           <Text style={styles.bigTitle}>{`Card ${navigation.getParam('id')}`}</Text>
         </Transition>
-        <Transition appear="horizontal" anchor={`image${navigation.getParam('id')}`}>
+        <Transition appear="fade">
           <ScrollView style={styles.commentsContainer}>
             <Text style={styles.comment}>Comment 1</Text>
             <Text style={styles.comment}>Comment 2</Text>

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -64,14 +64,14 @@ const styles = StyleSheet.create({
 });
 
 const Card = ({ navigation, avatar, imageSource, id }) => (
-  <Transition shared={`card${id}`} top appear="horizontal" disappear="fade" delay>
+  <Transition shared={`card${id}`} top appear="horizontal" disappear="fade">
     <TouchableOpacity
       activeOpacity={0.8}
       style={styles.card}
       onPress={() => navigation.navigate('screen2', { id, source: imageSource })}
       hitSlop={{ left: 20, top: 20, right: 20, bottom: 20 }}
     >
-      <Transition appear="fade">
+      <Transition appear="horizontal" disappear="fade">
         <View style={styles.imageHeader}>
           <Image source={avatar.source} style={styles.avatarImage} />
           <Text style={styles.avatarText}>{avatar.name}</Text>
@@ -80,7 +80,7 @@ const Card = ({ navigation, avatar, imageSource, id }) => (
       <Transition shared={`image${id}`}>
         <Image style={styles.smallImage} source={imageSource} />
       </Transition>
-      <Transition appear="fade">
+      <Transition appear="horizontal" disappear="fade">
         <View style={styles.imageHeader}>
           <Icon name="heart-outline" size={22} />
           <View style={{ width: 10 }} />
@@ -105,8 +105,8 @@ class Screen1 extends React.Component {
   }
 
   componentWillMount() {
-    const items = getRandomImages(1, Dimensions.get('window').width);
-    const users = getRandomImages(10, 30).map(img => ({
+    const items = getRandomImages(20, Dimensions.get('window').width);
+    const users = getRandomImages(20, 30).map(img => ({
       source: img,
       name: 'User name',
     }));
@@ -154,7 +154,7 @@ const Screen2 = ({ navigation }) => (
         <Transition shared={`text${navigation.getParam('id')}`}>
           <Text style={styles.bigTitle}>{`Card ${navigation.getParam('id')}`}</Text>
         </Transition>
-        <Transition>
+        <Transition appear="fade">
           <View style={styles.detailsContainer}>
             <Text>Image details</Text>
           </View>

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -67,6 +67,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     padding: 10,
+    paddingTop: 50,
   },
 });
 
@@ -88,7 +89,6 @@ const SmallAvatarImage = ({ source }) => (
   <Image source={source} style={styles.avatarSmallImage} />
 );
 
-
 const Avatar = ({ avatar }) => (
   <View style={styles.imageHeader}>
     <AvatarImage source={avatar.source} />
@@ -97,14 +97,14 @@ const Avatar = ({ avatar }) => (
 );
 
 const Card = ({ navigation, item, id }) => (
-  <Transition shared={`card${id}`} top appear="horizontal" disappear="fade">
+  <Transition shared={`card${id}`} appear="horizontal" disappear="fade">
     <TouchableOpacity
       activeOpacity={0.8}
       style={styles.card}
       onPress={() => navigation.navigate('screen2', { id, item })}
       hitSlop={{ left: 20, top: 20, right: 20, bottom: 20 }}
     >
-      <Transition appear="horizontal" disappear="fade">
+      <Transition shared={`avatar${id}`}>
         <Avatar avatar={item.avatar} />
       </Transition>
       <Transition shared={`image${id}`}>
@@ -155,16 +155,16 @@ const Screen2 = ({ navigation }) => (
   <View style={styles.container}>
     <Transition shared={`card${navigation.getParam('id')}`}>
       <View style={styles.bigCard}>
+        <Transition shared={`avatar${navigation.getParam('id')}`}>
+          <Avatar avatar={navigation.getParam('item').avatar} />
+        </Transition>
         <Transition shared={`image${navigation.getParam('id')}`}>
           <Image style={styles.bigImage} source={navigation.getParam('item').source} />
         </Transition>
         <Transition shared={`imageHeader${navigation.getParam('id')}`}>
           <ImageHeader />
         </Transition>
-        <Transition anchor={`image${navigation.getParam('id')}`}>
-          <Avatar avatar={navigation.getParam('item').avatar} />
-        </Transition>
-        <Transition anchor={`image${navigation.getParam('id')}`}>
+        <Transition anchor={`image${navigation.getParam('id')}`} appear="horizontal">
           <ScrollView style={styles.commentsContainer}>
             {navigation.getParam('item').comments.map((comment, index) => (
               <Comment key={index} comment={comment} />
@@ -213,7 +213,12 @@ class SharedElements extends React.Component {
 const createItemsData = () => {
   const users = getRandomImages(15, 30).map(img => ({
     source: img,
-    name: 'Christian Falch',
+    name: ['Marge Manns',
+      'Wallace Doe',
+      'Cheryle Hodnett',
+      'Jared Muszynski',
+      'Jayme Poyer',
+      'Gina Dennett'][Math.floor((Math.random() * 6))],
   }));
 
   const createComments = () => {

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -24,8 +24,23 @@ const styles = StyleSheet.create({
     width: Dimensions.get('window').width - 40,
     height: Dimensions.get('window').width - 60,
   },
+  imageHeader: {
+    padding: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatarImage: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+  },
+  avatarText: {
+    fontSize: 11,
+    marginLeft: 8,
+  },
   smallTitle: {
     margin: 10,
+    marginBottom: 20,
   },
   bigCard: {
     ...StyleSheet.absoluteFill,
@@ -39,22 +54,40 @@ const styles = StyleSheet.create({
   bigTitle: {
     margin: 20,
   },
+  detailsContainer: {
+    padding: 20,
+  },
   buttons: {
     flexDirection: 'row',
     padding: 20,
   },
 });
 
-const Card = ({ navigation, source, id }) => (
+const Card = ({ navigation, avatar, imageSource, id }) => (
   <Transition shared={`card${id}`} top appear="horizontal" disappear="fade" delay>
     <TouchableOpacity
       activeOpacity={0.8}
       style={styles.card}
-      onPress={() => navigation.navigate('screen2', { id, source })}
+      onPress={() => navigation.navigate('screen2', { id, source: imageSource })}
       hitSlop={{ left: 20, top: 20, right: 20, bottom: 20 }}
     >
+      <Transition appear="fade">
+        <View style={styles.imageHeader}>
+          <Image source={avatar.source} style={styles.avatarImage} />
+          <Text style={styles.avatarText}>{avatar.name}</Text>
+        </View>
+      </Transition>
       <Transition shared={`image${id}`}>
-        <Image style={styles.smallImage} source={source} />
+        <Image style={styles.smallImage} source={imageSource} />
+      </Transition>
+      <Transition appear="fade">
+        <View style={styles.imageHeader}>
+          <Icon name="heart-outline" size={22} />
+          <View style={{ width: 10 }} />
+          <Icon name="comment-outline" size={22} />
+          <View style={{ width: 10 }} />
+          <Icon name="paperclip" size={22} />
+        </View>
       </Transition>
       <Transition shared={`text${id}`}>
         <Text style={styles.smallTitle}>{`Card ${id}`}</Text>
@@ -68,34 +101,48 @@ const NavCard = withNavigation(Card);
 class Screen1 extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { item: [] };
+    this.state = { items: [], users: [] };
   }
 
   componentWillMount() {
-    const items = [];
-    const size = Dimensions.get('window').width;
-    const max = 10;
-    const randMax = 100;
-    for (let i = 0; i < max; i++) {
-      let randomNumber = Math.floor((Math.random() * randMax) + 1);
-      const idExists = (e) => e.id === randomNumber;
-      while (items.findIndex(idExists) > -1) {
-        randomNumber = Math.floor((Math.random() * randMax) + 1);
-      }
-
-      items.push({ url: `https://picsum.photos/${size}/${size}?image=${randomNumber}`, id: randomNumber });
-    }
-    this.setState((prevState) => ({ ...prevState, items }));
+    const items = getRandomImages(10, Dimensions.get('window').width);
+    const users = getRandomImages(10, 30).map(img => ({
+      source: img,
+      name: 'User name',
+    }));
+    this.setState((prevState) => ({ ...prevState, items, users }));
   }
 
   render() {
-    const { items } = this.state;
+    const { items, users } = this.state;
     return (
       <ScrollView style={styles.container}>
-        {items.map((source, index) => (<NavCard key={index} id={index} source={source} />))}
+        {items.map((source, index) => (
+          <NavCard
+            key={index}
+            id={index}
+            imageSource={source}
+            avatar={users[index]}
+          />
+        ))}
       </ScrollView>);
   }
 }
+
+const getRandomImages = (count: number, size: number) => {
+  const items = [];
+  const randMax = 100;
+  for (let i = 0; i < count; i++) {
+    let randomNumber = Math.floor((Math.random() * randMax) + 1);
+    const idExists = (e) => e.id === randomNumber;
+    while (items.findIndex(idExists) > -1) {
+      randomNumber = Math.floor((Math.random() * randMax) + 1);
+    }
+
+    items.push({ url: `https://picsum.photos/${size}/${size}?image=${randomNumber}`, id: randomNumber });
+  }
+  return items;
+};
 
 const Screen2 = ({ navigation }) => (
   <View style={styles.container}>
@@ -106,6 +153,11 @@ const Screen2 = ({ navigation }) => (
         </Transition>
         <Transition shared={`text${navigation.getParam('id')}`}>
           <Text style={styles.bigTitle}>{`Card ${navigation.getParam('id')}`}</Text>
+        </Transition>
+        <Transition>
+          <View style={styles.detailsContainer}>
+            <Text>Image details</Text>
+          </View>
         </Transition>
       </View>
     </Transition>

--- a/Examples/SharedElements/data.js
+++ b/Examples/SharedElements/data.js
@@ -1,0 +1,45 @@
+import { Dimensions } from 'react-native';
+
+export const createItemsData = () => {
+  const users = getRandomImages(15, 30).map(img => ({
+    source: img,
+    name: ['Marge Manns',
+      'Wallace Doe',
+      'Cheryle Hodnett',
+      'Jared Muszynski',
+      'Jayme Poyer',
+      'Gina Dennett'][Math.floor((Math.random() * 6))],
+  }));
+
+  const createComments = () => {
+    const comments = [];
+    for (let i = 0; i < Math.floor((Math.random() * 6) + 4); i++) {
+      comments.push({
+        text: ['Great picture! Thanks', 'I like it!', 'Wow! Great', 'Cool!', 'Thanks :-)', ':-)'][Math.floor((Math.random() * 6))],
+        avatar: users[Math.floor((Math.random() * 15))],
+      });
+    }
+    return comments;
+  };
+  const items = getRandomImages(15, Dimensions.get('window').width).map(img => ({
+    source: img,
+    comments: createComments(),
+    avatar: users[Math.floor((Math.random() * 15))],
+  }));
+  return items;
+};
+
+const getRandomImages = (count: number, size: number) => {
+  const items = [];
+  const randMax = 100;
+  for (let i = 0; i < count; i++) {
+    let randomNumber = Math.floor((Math.random() * randMax) + 1);
+    const idExists = (e) => e.id === randomNumber;
+    while (items.findIndex(idExists) > -1) {
+      randomNumber = Math.floor((Math.random() * randMax) + 1);
+    }
+
+    items.push({ url: `https://picsum.photos/${size}/${size}?image=${randomNumber}`, id: randomNumber });
+  }
+  return items;
+};

--- a/Examples/SharedElements/index.js
+++ b/Examples/SharedElements/index.js
@@ -1,77 +1,13 @@
 import React from 'react';
-import { View, Text, ScrollView, Image, Dimensions, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, Image, Dimensions, TouchableOpacity } from 'react-native';
 import { withNavigation } from 'react-navigation';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { Transition, createFluidNavigator } from '../lib';
+import { Transition, createFluidNavigator } from '../../lib';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  card: {
-    backgroundColor: '#FFF',
-    flexDirection: 'column',
-    justifyContent: 'center',
-    margin: 20,
-    marginTop: 10,
-    marginBottom: 10,
-    borderRadius: 4,
-    shadowOpacity: 0.3,
-    shadowColor: '#AAA',
-    shadowOffset: { width: 0, height: 4 },
-  },
-  smallImage: {
-    width: Dimensions.get('window').width - 40,
-    height: Dimensions.get('window').width - 60,
-  },
-  imageHeader: {
-    padding: 10,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  avatarImage: {
-    width: 20,
-    height: 20,
-    borderRadius: 10,
-  },
-  avatarSmallImage: {
-    width: 12,
-    height: 12,
-    borderRadius: 6,
-  },
-  avatarText: {
-    fontSize: 11,
-    marginLeft: 8,
-  },
-  bigCard: {
-    ...StyleSheet.absoluteFill,
-    backgroundColor: '#FFF',
-    justifyContent: 'flex-start',
-  },
-  bigImage: {
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').width,
-  },
-  commentsContainer: {
-  },
-  commentRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: 10,
-    paddingVertical: 6,
-  },
-  comment: {
-    fontSize: 11,
-    paddingLeft: 6,
-  },
-  buttons: {
-    flexDirection: 'row',
-    padding: 10,
-    paddingTop: 50,
-  },
-});
+import styles from './styles';
+import { createItemsData } from './data';
 
-const ImageHeader = () => (
+const ImageFooter = () => (
   <View style={styles.imageHeader}>
     <Icon name="heart-outline" size={22} />
     <View style={{ width: 10 }} />
@@ -111,7 +47,7 @@ const Card = ({ navigation, item, id }) => (
         <Image style={styles.smallImage} source={item.source} />
       </Transition>
       <Transition shared={`imageHeader${id}`}>
-        <ImageHeader />
+        <ImageFooter />
       </Transition>
     </TouchableOpacity>
   </Transition>
@@ -162,9 +98,9 @@ const Screen2 = ({ navigation }) => (
           <Image style={styles.bigImage} source={navigation.getParam('item').source} />
         </Transition>
         <Transition shared={`imageHeader${navigation.getParam('id')}`}>
-          <ImageHeader />
+          <ImageFooter />
         </Transition>
-        <Transition anchor={`image${navigation.getParam('id')}`} appear="horizontal">
+        <Transition anchor={`card${navigation.getParam('id')}`}>
           <ScrollView style={styles.commentsContainer}>
             {navigation.getParam('item').comments.map((comment, index) => (
               <Comment key={index} comment={comment} />
@@ -193,7 +129,6 @@ const Navigator = createFluidNavigator({
   navigationOptions: {
     gesturesEnabled: true,
     gestureResponseDistance: {
-      horizontal: Dimensions.get('window').width,
       vertical: Dimensions.get('window').height,
     },
   },
@@ -209,48 +144,5 @@ class SharedElements extends React.Component {
     );
   }
 }
-
-const createItemsData = () => {
-  const users = getRandomImages(15, 30).map(img => ({
-    source: img,
-    name: ['Marge Manns',
-      'Wallace Doe',
-      'Cheryle Hodnett',
-      'Jared Muszynski',
-      'Jayme Poyer',
-      'Gina Dennett'][Math.floor((Math.random() * 6))],
-  }));
-
-  const createComments = () => {
-    const comments = [];
-    for (let i = 0; i < Math.floor((Math.random() * 6) + 4); i++) {
-      comments.push({
-        text: ['Great picture! Thanks', 'I like it!', 'Wow! Great', 'Cool!', 'Thanks :-)', ':-)'][Math.floor((Math.random() * 6))],
-        avatar: users[Math.floor((Math.random() * 15))],
-      });
-    }
-    return comments;
-  };
-  const items = getRandomImages(15, Dimensions.get('window').width).map(img => ({
-    source: img,
-    comments: createComments(),
-    avatar: users[Math.floor((Math.random() * 15))],
-  }));
-  return items;
-};
-const getRandomImages = (count: number, size: number) => {
-  const items = [];
-  const randMax = 100;
-  for (let i = 0; i < count; i++) {
-    let randomNumber = Math.floor((Math.random() * randMax) + 1);
-    const idExists = (e) => e.id === randomNumber;
-    while (items.findIndex(idExists) > -1) {
-      randomNumber = Math.floor((Math.random() * randMax) + 1);
-    }
-
-    items.push({ url: `https://picsum.photos/${size}/${size}?image=${randomNumber}`, id: randomNumber });
-  }
-  return items;
-};
 
 export default SharedElements;

--- a/Examples/SharedElements/styles.js
+++ b/Examples/SharedElements/styles.js
@@ -1,0 +1,68 @@
+import { Dimensions, StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  card: {
+    backgroundColor: '#FFF',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    margin: 20,
+    marginTop: 10,
+    marginBottom: 10,
+    borderRadius: 4,
+    shadowOpacity: 0.3,
+    shadowColor: '#AAA',
+    shadowOffset: { width: 0, height: 4 },
+  },
+  smallImage: {
+    width: Dimensions.get('window').width - 40,
+    height: Dimensions.get('window').width - 60,
+  },
+  imageHeader: {
+    padding: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatarImage: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+  },
+  avatarSmallImage: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  avatarText: {
+    fontSize: 11,
+    marginLeft: 8,
+  },
+  bigCard: {
+    ...StyleSheet.absoluteFill,
+    backgroundColor: '#FFF',
+    justifyContent: 'flex-start',
+  },
+  bigImage: {
+    width: Dimensions.get('window').width,
+    height: Dimensions.get('window').width,
+  },
+  commentsContainer: {
+  },
+  commentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 10,
+    paddingVertical: 6,
+  },
+  comment: {
+    fontSize: 11,
+    paddingLeft: 6,
+  },
+  buttons: {
+    flexDirection: 'row',
+    padding: 10,
+    paddingTop: 50,
+  },
+});

--- a/Examples/ShoeShop.js
+++ b/Examples/ShoeShop.js
@@ -129,7 +129,7 @@ const Screen1 = (props) => (
   <View style={styles.container}>
     <TouchableWithoutFeedback onPress={() => props.navigation.navigate('screen2')}>
       <View style={styles.top1}>
-        <Transition appear="left" shared="paper">
+        <Transition appear="left" shared="paper" flat>
           <View style={styles.paper1} />
         </Transition>
         <Transition appear="right" shared="image">

--- a/lib/FluidTransitioner.js
+++ b/lib/FluidTransitioner.js
@@ -58,9 +58,9 @@ class FluidTransitioner extends React.Component<*> {
   }
 
   getChildContext() {
+    const { navigation } = this.props;
     return {
-      route: this.props.navigation.state.routes[
-        this.props.navigation.state.index].routeName,
+      route: navigation.state.routes[navigation.state.index].key,
       onSceneReady: this._onSceneReady,
       getTransitionConfig: this._getSceneTransitionConfiguration,
     };

--- a/lib/Interpolators/getAnchoredElements.js
+++ b/lib/Interpolators/getAnchoredElements.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
 
 import TransitionItem from '../TransitionItem';
 import { createAnimatedWrapper } from '../Utils';
@@ -10,10 +9,9 @@ const getAnchoredElements = (sharedElements: Array<any>, getInterpolationFunctio
     if (p.toItem.anchors && p.toItem.anchors.length > 0) {
       p.toItem.anchors.forEach(a => {
         const scale = p.fromItem.scaleRelativeTo(p.toItem);
-        const scaleOp = p.toItem.scaleRelativeTo(p.fromItem);
 
         retVal.push(createAnchoredView(a, p.toItem, p.fromItem,
-          getInterpolationFunction, scale, scaleOp));
+          getInterpolationFunction, scale));
       });
     }
   });
@@ -21,7 +19,7 @@ const getAnchoredElements = (sharedElements: Array<any>, getInterpolationFunctio
 };
 
 const createAnchoredView = (anchor: TransitionItem, to: TransitionItem,
-  from: TransitionItem, getInterpolationFunction: Function, scale: any, scaleOp: any) => {
+  from: TransitionItem, getInterpolationFunction: Function, scale: any) => {
   const interpolator = getInterpolationFunction(true);
 
   const scaleX = interpolator.interpolate({
@@ -91,24 +89,5 @@ const createAnchoredView = (anchor: TransitionItem, to: TransitionItem,
   const retVal = createAnimatedWrapper({ component, nativeStyles });
   return retVal;
 };
-
-const ptToString = (p) => `x: ${p.x} y: ${p.y}`;
-
-const styles = StyleSheet.create({
-  anchorElement: {
-    // borderColor: '#00F',
-    // borderWidth: 1,
-    position: 'absolute',
-    margin: 0,
-    marginVertical: 0,
-    marginHorizontal: 0,
-    marginTop: 0,
-    marginBottom: 0,
-    marginLeft: 0,
-    marginRight: 0,
-    marginStart: 0,
-    marginEnd: 0,
-  },
-});
 
 export { getAnchoredElements };

--- a/lib/Interpolators/getBackgroundInterpolator.js
+++ b/lib/Interpolators/getBackgroundInterpolator.js
@@ -4,5 +4,9 @@ import { getStyleInterpolator } from './getStyleInterpolator';
 
 export const getBackgroundInterpolator = (spec: InterpolatorSpecification): StyleSheet.Styles => {
   const backgroundColor = getStyleInterpolator('backgroundColor', 'transparent', false, spec);
-  return { animationStyles: { backgroundColor } };
+  const opacity = getStyleInterpolator('opacity', 1, true, spec, false);
+  return {
+    nativeAnimationStyles: { opacity },
+    animationStyles: { backgroundColor },
+  };
 };

--- a/lib/Interpolators/getSharedElements.js
+++ b/lib/Interpolators/getSharedElements.js
@@ -20,12 +20,13 @@ const getSharedElements = (sharedElements: Array<any>,
   const key = `so-${idx.toString()}`;
   const animationStyle = transitionStyles.styles;
   const nativeAnimationStyle = [transitionStyles.nativeStyles];
+  const resolvedMetrics = getResolvedMetrics(fromItem, fromItem.metrics);
   const overrideStyles = {
     position: 'absolute',
-    left: fromItem.metrics.x,
-    top: fromItem.metrics.y,
-    width: fromItem.metrics.width,
-    height: fromItem.metrics.height,
+    left: resolvedMetrics.x,
+    top: resolvedMetrics.y,
+    width: resolvedMetrics.width,
+    height: resolvedMetrics.height,
   };
 
   const props = { ...element.props, __index: fromItem.index };
@@ -101,6 +102,18 @@ const getTransitionStyle = (
       ...mergeStyles(styles),
     },
   };
+};
+
+const getResolvedMetrics = (item: TransitionItem, metrics: any) => {
+  const style = item.getFlattenedStyle();
+  if (style && style.margin) {
+    return {
+      x: metrics.x - style.margin,
+      y: metrics.y - style.margin,
+      width: metrics.width,
+      height: metrics.height };
+  }
+  return metrics;
 };
 
 export { getSharedElements };

--- a/lib/Interpolators/getSharedElements.js
+++ b/lib/Interpolators/getSharedElements.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Dimensions } from 'react-native';
 
 import TransitionItem from '../TransitionItem';
-import { createAnimatedWrapper, mergeStyles } from '../Utils';
+import { createAnimatedWrapper, getResolvedMetrics, mergeStyles } from '../Utils';
 
 import { getInterpolatorTypes } from './InterpolatorTypes';
 import { InterpolatorSpecification } from '../Types/InterpolatorSpecification';

--- a/lib/Interpolators/getSharedElements.js
+++ b/lib/Interpolators/getSharedElements.js
@@ -104,16 +104,4 @@ const getTransitionStyle = (
   };
 };
 
-const getResolvedMetrics = (item: TransitionItem, metrics: any) => {
-  const style = item.getFlattenedStyle();
-  if (style && style.margin) {
-    return {
-      x: metrics.x - style.margin,
-      y: metrics.y - style.margin,
-      width: metrics.width,
-      height: metrics.height };
-  }
-  return metrics;
-};
-
 export { getSharedElements };

--- a/lib/Interpolators/getStyleInterpolator.js
+++ b/lib/Interpolators/getStyleInterpolator.js
@@ -6,22 +6,27 @@ export const getStyleInterpolator = (
   defaultValue: any,
   useNative: boolean,
   spec: InterpolatorSpecification,
+  scale: boolean = true,
 ): StyleSheet.Styles => {
   const fromStyle = spec.from.style;
   const toStyle = spec.to.style;
 
   if ((!fromStyle || !fromStyle[key])
-    && (!toStyle || !toStyle[key])) return null;
+    && (!toStyle || !toStyle[key])) return null;
 
-  const fromValue = fromStyle && fromStyle[key] ? fromStyle[key] : defaultValue;
-  let toValue = toStyle && toStyle[key] ? toStyle[key] : defaultValue;
+  const fromValue = fromStyle && fromStyle[key] !== undefined ? fromStyle[key] : defaultValue;
+  let toValue = toStyle && toStyle[key] !== undefined ? toStyle[key] : defaultValue;
 
   if (fromValue === toValue) return null;
 
   // Handle scaling of numeric values
   const parsed = parseInt(toValue, 10);
-  if (!Number.isNaN(parsed)) {
-    toValue = parsed / spec.scaleX;
+  if (scale) {
+    if (!Number.isNaN(parsed)) {
+      toValue = parsed / spec.scaleX;
+    }
+  } else {
+    toValue = parsed;
   }
 
   const interpolator = (spec.getInterpolation(useNative))

--- a/lib/TransitionItem.js
+++ b/lib/TransitionItem.js
@@ -14,6 +14,7 @@ export default class TransitionItem {
     name: string, route: string, reactElement: Object,
     shared: boolean, appear: string, disappear: string,
     delay: boolean, index: number, anchor: string, animated: string,
+    top: boolean,
   ) {
     this.name = name;
     this.route = route;
@@ -25,6 +26,7 @@ export default class TransitionItem {
     this.index = index;
     this.anchor = anchor;
     this.animated = animated;
+    this.top = top;
   }
 
   name: string
@@ -55,9 +57,19 @@ export default class TransitionItem {
 
   animated: string
 
+  top: string
+
   _rotation: any;
 
   _testRenderer: any;
+
+  forceUpdate() {
+    if (this.reactElement._isMounted) { this.reactElement.forceUpdate(); }
+  }
+
+  getIsMounted() {
+    return this.reactElement._isMounted;
+  }
 
   getNodeHandle() {
     return this.reactElement.getNodeHandle();

--- a/lib/TransitionItem.js
+++ b/lib/TransitionItem.js
@@ -48,7 +48,9 @@ export default class TransitionItem {
 
   layoutReady: boolean
 
-  flattenedStyle: ?any
+  flattenedStyle: ?StyleSheet.Styles
+
+  flattenedItemStyle: ?StyleSheet.Styles
 
   boundingBoxMetrics: Metrics
 
@@ -80,6 +82,16 @@ export default class TransitionItem {
 
   getViewRef() {
     return this.reactElement.getViewRef();
+  }
+
+  getItemStyle() {
+    if (!this.flattenedItemStyle) {
+      const element = React.Children.only(this.reactElement.props.children);
+      if (!element) { return {}; }
+      const { style } = element.props;
+      this.flattenedItemStyle = StyleSheet.flatten(style);
+    }
+    return this.flattenedItemStyle;
   }
 
   getFlattenedStyle(refresh = false) {

--- a/lib/TransitionItem.js
+++ b/lib/TransitionItem.js
@@ -14,7 +14,7 @@ export default class TransitionItem {
     name: string, route: string, reactElement: Object,
     shared: boolean, appear: string, disappear: string,
     delay: boolean, index: number, anchor: string, animated: string,
-    top: boolean, parent: TransitionItem,
+    flat: boolean, parent: TransitionItem,
   ) {
     this.name = name;
     this.route = route;
@@ -26,7 +26,7 @@ export default class TransitionItem {
     this.index = index;
     this.anchor = anchor;
     this.animated = animated;
-    this.top = top;
+    this.flat = flat;
     this.parent = parent;
   }
 
@@ -60,7 +60,7 @@ export default class TransitionItem {
 
   animated: string
 
-  top: string
+  flat: string
 
   parent: TransitionItem
 

--- a/lib/TransitionItem.js
+++ b/lib/TransitionItem.js
@@ -14,7 +14,7 @@ export default class TransitionItem {
     name: string, route: string, reactElement: Object,
     shared: boolean, appear: string, disappear: string,
     delay: boolean, index: number, anchor: string, animated: string,
-    top: boolean,
+    top: boolean, parent: TransitionItem,
   ) {
     this.name = name;
     this.route = route;
@@ -27,6 +27,7 @@ export default class TransitionItem {
     this.anchor = anchor;
     this.animated = animated;
     this.top = top;
+    this.parent = parent;
   }
 
   name: string
@@ -58,6 +59,8 @@ export default class TransitionItem {
   animated: string
 
   top: string
+
+  parent: TransitionItem
 
   _rotation: any;
 
@@ -136,8 +139,6 @@ export default class TransitionItem {
       this.metrics = { x: x - viewMetrics.x, y: y - viewMetrics.y, width, height };
       this.boundingBoxMetrics = this.metrics;
     }
-
-    // console.log(this.name  + "/" + this.route + "-" + this.metrics.x + "," + this.metrics.y + " - " + this.metrics.width + "," + this.metrics.height);
   }
 
   getRotation() {
@@ -148,9 +149,9 @@ export default class TransitionItem {
         if (ri.rotate.rotate) {
           const rotation: String = ri.rotate.rotate;
           if (rotation.endsWith('deg')) {
-            retVal = { type: 'deg', value: parseInt(rotation.substring(0, rotation.length - 3)) };
-          } else if (rotation.endsWith('rad')) {
-            retVal = { type: 'rad', value: parseInt(rotation.substring(0, rotation.length - 3)) };
+            retVal = { type: 'deg', value: parseInt(rotation.substring(0, rotation.length - 3), 10) };
+          } else if (rotation.endsWith('rad')) {
+            retVal = { type: 'rad', value: parseInt(rotation.substring(0, rotation.length - 3), 10) };
           }
         }
       }

--- a/lib/TransitionItems.js
+++ b/lib/TransitionItems.js
@@ -40,7 +40,7 @@ export default class TransitionItems {
         routes.push(this._items[i].route);
       }
     }
-    if (routes.length != 2) {
+    if (routes.length !== 2) {
       throw new Error(`Number of routes should be 2, was ${routes.length}`);
     }
 
@@ -60,8 +60,8 @@ export default class TransitionItems {
     const itemPairs = this._getItemPairs(fromRoute, toRoute)
       .filter(pair => pair.toItem !== undefined && pair.fromItem !== undefined);
 
-    let items = this._items.filter(e => (e.appear !== undefined || e.disappear !== undefined)
-      && (e.route === fromRoute || e.route === toRoute));
+    let items = this._items.filter(e => e.getIsMounted() && (e.appear !== undefined
+      || e.disappear !== undefined) && (e.route === fromRoute || e.route === toRoute));
 
     items = items.filter(e => itemPairs.findIndex(p => (e.name === p.fromItem.name
       && e.route === p.fromItem.route)
@@ -71,7 +71,7 @@ export default class TransitionItems {
   }
 
   _getNamePairMap(fromRoute: string, toRoute: string): Map<TransitionItem, TransitionItem> {
-    const nameMap = this._items.reduce((map, item) => {
+    const nameMap = this._items.filter(p => p.getIsMounted()).reduce((map, item) => {
       let pairByName = map.get(item.name);
       if (!pairByName) {
         pairByName = {};

--- a/lib/TransitionItemsView.js
+++ b/lib/TransitionItemsView.js
@@ -273,7 +273,7 @@ export default class TransitionItemsView extends React.Component<
 
     // Update visibility style based on calculation by re-rendering all transition elements.
     // Ref, https://github.com/fram-x/FluidTransitions/issues/8
-    this._transitionItems.getItems().forEach(item => item.reactElement.forceUpdate());
+    this._transitionItems.getItems().forEach(item => item.forceUpdate());
 
     // Wait a little bit to give the layout system some time to reconcile
     let measureAndUpdateFunc = async () => {

--- a/lib/TransitionItemsView.js
+++ b/lib/TransitionItemsView.js
@@ -374,15 +374,32 @@ export default class TransitionItemsView extends React.Component<
     getTransitionConfig: PropTypes.func,
   }
 
+  registerItem = (item) => {
+    this._transitionItems.add(item);
+  }
+
+  unregisterItem = (name, route) => {
+    this._transitionItems.remove(name, route);
+  }
+
+  getIndex = () => {
+    const { index } = this.state;
+    return index;
+  }
+
+  getDirection = () => {
+    const { direction } = this.state;
+    return (direction || NavigationDirection.unknown);
+  }
+
   getChildContext() {
     return {
-      register: (item) => this._transitionItems.add(item),
-      unregister: (name, route) => this._transitionItems.remove(name, route),
+      register: this.registerItem,
+      unregister: this.unregisterItem,
       getTransitionProgress: this.getTransitionProgress,
       getDirectionForRoute: this.getDirectionForRoute,
-      getIndex: () => this.state.index,
-      getDirection: () => (this.state.direction
-        ? this.state.direction : NavigationDirection.unknown),
+      getIndex: this.getIndex,
+      getDirection: this.getDirection,
       getIsPartOfSharedTransition: this.getIsPartOfSharedTransition,
       getIsPartOfTransition: this.getIsPartOfTransition,
       getIsAnchored: this.getIsAnchored,

--- a/lib/TransitionOverlayView.js
+++ b/lib/TransitionOverlayView.js
@@ -74,12 +74,23 @@ class TransitionOverlayView extends React.Component<Props> {
     this._interpolation = null;
     this._nativeInterpolation = null;
 
+    // If any of the element has top on it, we should sort using
+    // the algorithm fromFirst and the to-items. We will also sort
+    // transition and shared items through a parent-child tree
     if (sharedElements.find(pair => pair.toItem.top || pair.fromItem.top)) {
-      const transitionViewsFrom = getTransitionElements(transitionElements
-        .filter(i => i.route === from), transitionContext);
-
-      const transitionViewsTo = getTransitionElements(transitionElements
-        .filter(i => i.route === to), transitionContext);
+      const transitionElementsFrom = transitionElements.filter(i => i.route === from);
+      const transitionElementsTo = transitionElements.filter(i => i.route === to);
+      const fromToBeMoved = transitionElements.filter(i => i.parent
+        && sharedElements.find(s => s.name === i.parent.name && s.route === i.parent.route));
+      fromToBeMoved.forEach(f => {
+        const index = transitionElementsFrom.indexOf(f);
+        if (index !== -1) {
+          transitionElementsFrom.splice(index, 1);
+          transitionElementsTo.push(f);
+        }
+      });
+      const transitionViewsFrom = getTransitionElements(transitionElementsFrom, transitionContext);
+      const transitionViewsTo = getTransitionElements(transitionElementsTo, transitionContext);
 
       const sharedElementViews = getSharedElements(sharedElements, this.getInterpolation);
       const anchoredViews = getAnchoredElements(sharedElements, this.getInterpolation);

--- a/lib/TransitionOverlayView.js
+++ b/lib/TransitionOverlayView.js
@@ -81,7 +81,9 @@ class TransitionOverlayView extends React.Component<Props> {
       const transitionElementsFrom = transitionElements.filter(i => i.route === from);
       const transitionElementsTo = transitionElements.filter(i => i.route === to);
       const fromToBeMoved = transitionElements.filter(i => i.parent
-        && sharedElements.find(s => s.toItem.name === i.parent.name && s.toItem.route === i.parent.route));
+        && sharedElements.find(s => s.toItem.name === i.parent.name
+          && s.toItem.route === i.parent.route));
+
       fromToBeMoved.forEach(f => {
         const index = transitionElementsFrom.indexOf(f);
         if (index !== -1) {

--- a/lib/TransitionOverlayView.js
+++ b/lib/TransitionOverlayView.js
@@ -81,7 +81,7 @@ class TransitionOverlayView extends React.Component<Props> {
       const transitionElementsFrom = transitionElements.filter(i => i.route === from);
       const transitionElementsTo = transitionElements.filter(i => i.route === to);
       const fromToBeMoved = transitionElements.filter(i => i.parent
-        && sharedElements.find(s => s.name === i.parent.name && s.route === i.parent.route));
+        && sharedElements.find(s => s.toItem.name === i.parent.name && s.toItem.route === i.parent.route));
       fromToBeMoved.forEach(f => {
         const index = transitionElementsFrom.indexOf(f);
         if (index !== -1) {

--- a/lib/TransitionOverlayView.js
+++ b/lib/TransitionOverlayView.js
@@ -57,6 +57,7 @@ class TransitionOverlayView extends React.Component<Props> {
     let { transitionElements, sharedElements } = this.props;
     const from = fromRoute;
     const to = toRoute;
+
     transitionElements = transitionElements ? transitionElements
       .filter(i => i.route === from || i.route === to) : [];
 
@@ -73,12 +74,32 @@ class TransitionOverlayView extends React.Component<Props> {
     this._interpolation = null;
     this._nativeInterpolation = null;
 
+    if (sharedElements.find(pair => pair.toItem.top || pair.fromItem.top)) {
+      const transitionViewsFrom = getTransitionElements(transitionElements
+        .filter(i => i.route === from), transitionContext);
+
+      const transitionViewsTo = getTransitionElements(transitionElements
+        .filter(i => i.route === to), transitionContext);
+
+      const sharedElementViews = getSharedElements(sharedElements, this.getInterpolation);
+      const anchoredViews = getAnchoredElements(sharedElements, this.getInterpolation);
+
+      const fromViews = sortBy([...transitionViewsFrom], 'props.index');
+      const toViews = sortBy([...transitionViewsTo, ...sharedElementViews, ...anchoredViews], 'props.index');
+      const views = fromViews.concat(toViews);
+      return (
+        <Animated.View style={[styles.overlay, this.getVisibilityStyle()]} pointerEvents="none">
+          {views}
+        </Animated.View>
+      );
+    }
+
     const transitionViews = getTransitionElements(transitionElements, transitionContext);
+
     const sharedElementViews = getSharedElements(sharedElements, this.getInterpolation);
     const anchoredViews = getAnchoredElements(sharedElements, this.getInterpolation);
 
-    let views = [...transitionViews, ...sharedElementViews, ...anchoredViews];
-    views = sortBy(views, 'props.index');
+    const views = sortBy([...transitionViews, ...sharedElementViews, ...anchoredViews], 'props.index');
 
     return (
       <Animated.View style={[styles.overlay, this.getVisibilityStyle()]} pointerEvents="none">
@@ -204,6 +225,16 @@ class TransitionOverlayView extends React.Component<Props> {
 
   componentWillUnmount() {
     this._isMounted = false;
+  }
+
+  getChildContext() {
+    return {
+      isOverlayChild: true,
+    };
+  }
+
+  static childContextTypes= {
+    isOverlayChild: PropTypes.bool,
   }
 
   static contextTypes = {

--- a/lib/TransitionOverlayView.js
+++ b/lib/TransitionOverlayView.js
@@ -74,46 +74,42 @@ class TransitionOverlayView extends React.Component<Props> {
     this._interpolation = null;
     this._nativeInterpolation = null;
 
-    // If any of the element has top on it, we should sort using
-    // the algorithm fromFirst and the to-items. We will also sort
-    // transition and shared items through a parent-child tree
-    if (sharedElements.find(pair => pair.toItem.top || pair.fromItem.top)) {
-      const transitionElementsFrom = transitionElements.filter(i => i.route === from);
-      const transitionElementsTo = transitionElements.filter(i => i.route === to);
-      const fromToBeMoved = transitionElements.filter(i => i.parent
-        && sharedElements.find(s => s.toItem.name === i.parent.name
-          && s.toItem.route === i.parent.route));
-
-      fromToBeMoved.forEach(f => {
-        const index = transitionElementsFrom.indexOf(f);
-        if (index !== -1) {
-          transitionElementsFrom.splice(index, 1);
-          transitionElementsTo.push(f);
-        }
-      });
-      const transitionViewsFrom = getTransitionElements(transitionElementsFrom, transitionContext);
-      const transitionViewsTo = getTransitionElements(transitionElementsTo, transitionContext);
+    if (sharedElements.find(pair => pair.toItem.flat || pair.fromItem.flat)) {
+      const transitionViews = getTransitionElements(transitionElements, transitionContext);
 
       const sharedElementViews = getSharedElements(sharedElements, this.getInterpolation);
       const anchoredViews = getAnchoredElements(sharedElements, this.getInterpolation);
 
-      const fromViews = sortBy([...transitionViewsFrom], 'props.index');
-      const toViews = sortBy([...transitionViewsTo, ...sharedElementViews, ...anchoredViews], 'props.index');
-      const views = fromViews.concat(toViews);
+      const views = sortBy([...transitionViews, ...sharedElementViews, ...anchoredViews], 'props.index');
+
       return (
         <Animated.View style={[styles.overlay, this.getVisibilityStyle()]} pointerEvents="none">
           {views}
         </Animated.View>
       );
     }
+    const transitionElementsFrom = transitionElements.filter(i => i.route === from);
+    const transitionElementsTo = transitionElements.filter(i => i.route === to);
+    const fromToBeMoved = transitionElements.filter(i => i.parent
+        && sharedElements.find(s => s.toItem.name === i.parent.name
+          && s.toItem.route === i.parent.route));
 
-    const transitionViews = getTransitionElements(transitionElements, transitionContext);
+    fromToBeMoved.forEach(f => {
+      const index = transitionElementsFrom.indexOf(f);
+      if (index !== -1) {
+        transitionElementsFrom.splice(index, 1);
+        transitionElementsTo.push(f);
+      }
+    });
+    const transitionViewsFrom = getTransitionElements(transitionElementsFrom, transitionContext);
+    const transitionViewsTo = getTransitionElements(transitionElementsTo, transitionContext);
 
     const sharedElementViews = getSharedElements(sharedElements, this.getInterpolation);
     const anchoredViews = getAnchoredElements(sharedElements, this.getInterpolation);
 
-    const views = sortBy([...transitionViews, ...sharedElementViews, ...anchoredViews], 'props.index');
-
+    const fromViews = sortBy([...transitionViewsFrom], 'props.index');
+    const toViews = sortBy([...transitionViewsTo, ...sharedElementViews, ...anchoredViews], 'props.index');
+    const views = fromViews.concat(toViews);
     return (
       <Animated.View style={[styles.overlay, this.getVisibilityStyle()]} pointerEvents="none">
         {views}

--- a/lib/TransitionRouteView.js
+++ b/lib/TransitionRouteView.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { StyleSheet } from 'react-native';
 import { Screen } from 'react-native-screens';
 
-const EPS = 1e-5;
-
 type TransitionRouteViewProps = {
   children: React.Node,
   style: StyleSheet.Styles,

--- a/lib/TransitionView.js
+++ b/lib/TransitionView.js
@@ -21,6 +21,7 @@ type TransitionProps = {
   innerRef: ?any,
   children: Array<any>,
   zIndex: Number,
+  top: ?boolean,
 }
 
 class Transition extends React.Component<TransitionProps> {
@@ -35,6 +36,18 @@ class Transition extends React.Component<TransitionProps> {
     getIsPartOfSharedTransition: PropTypes.func,
     getIsPartOfTransition: PropTypes.func,
     getIsAnchored: PropTypes.func,
+    isOverlayChild: PropTypes.bool,
+    getParentTransition: PropTypes.func,
+  }
+
+  static childContextTypes = {
+    getParentTransition: PropTypes.func,
+  }
+
+  getChildContext() {
+    return {
+      getParentTransition: () => this,
+    };
   }
 
   constructor(props: TransitionProps, context: any) {
@@ -55,19 +68,60 @@ class Transition extends React.Component<TransitionProps> {
 
   _outerAnimatedComponent: any;
 
+  _index: number;
+
+  _isPartOfSharedTransition: boolean;
+
+  _isPartOfTransition: boolean;
+
+  _isAnchored: boolean;
+
   shouldComponentUpdate(nextProps) {
-    return (this.props !== nextProps);
+    const { name, appear, disappear, shared, delay, animated, anchor, zIndex, top } = this.props;
+    if (name !== nextProps.name
+      || appear !== nextProps.appear
+      || disappear !== nextProps.disappear
+      || shared !== nextProps.shared
+      || delay !== nextProps.delay
+      || animated !== nextProps.animated
+      || anchor !== nextProps.anchor
+      || zIndex !== nextProps.zIndex
+      || top !== nextProps.top) return true;
+
+    const { getIndex, getIsAnchored, getIsPartOfSharedTransition,
+      getIsPartOfTransition } = this.context;
+
+    if (!getIndex || !getIsAnchored || !getIsPartOfSharedTransition
+      || !getIsPartOfTransition) {
+      return true;
+    }
+
+    const index = getIndex();
+    const isPartOfSharedTransition = getIsPartOfSharedTransition(this._getName(), this._route);
+    const isPartOfTransition = getIsPartOfTransition(this._getName(), this._route);
+    const isAnchored = getIsAnchored(this._getName(), this._route);
+
+    if (index !== this._index
+      || isPartOfSharedTransition !== this._isPartOfSharedTransition
+      || isPartOfTransition !== this._isPartOfTransition
+      || isAnchored !== this._isAnchored) return true;
+
+    return false;
   }
 
   componentWillMount() {
-    const { route, register } = this.context;
-    const { shared, appear, disappear, delay, zIndex, anchor, animated } = this.props;
+    const { route, register, isOverlayChild } = this.context;
+    const { shared, appear, top, disappear, delay, zIndex, anchor, animated } = this.props;
     if (register) {
       this._route = route;
-      register(new TransitionItem(
-        this._getName(), route, this, shared !== undefined, appear,
-        disappear, delay !== undefined, zIndex || _zIndex++, anchor, animated,
-      ));
+      if (!isOverlayChild) {
+        this._route = route;
+        register(new TransitionItem(
+          this._getName(), route, this, shared !== undefined, appear,
+          disappear, delay !== undefined, zIndex || _zIndex++, anchor, animated,
+          top,
+        ));
+      }
     }
   }
 
@@ -77,8 +131,8 @@ class Transition extends React.Component<TransitionProps> {
 
   componentWillUnmount() {
     this._isMounted = false;
-    const { unregister } = this.context;
-    if (unregister) {
+    const { unregister, isOverlayChild } = this.context;
+    if (unregister && !isOverlayChild) {
       unregister(this._getName(), this._route);
     }
   }
@@ -127,24 +181,30 @@ class Transition extends React.Component<TransitionProps> {
 
   getVisibilityStyle() {
     const { getTransitionProgress, getIndex, getIsAnchored,
-      getIsPartOfSharedTransition, getIsPartOfTransition } = this.context;
+      getIsPartOfSharedTransition, getIsPartOfTransition,
+      isOverlayChild } = this.context;
+
     if (!getTransitionProgress || !getIndex || !getIsAnchored
       || !getIsPartOfSharedTransition || !getIsPartOfTransition) return {};
 
     const progress = getTransitionProgress();
-    const index = getIndex();
-    if (!progress || index === undefined) return { };
+    this._index = getIndex();
+    if (!progress || this._index === undefined) return { };
 
-    const inputRange = [index - 1, (index - 1) + Constants.OP, index - Constants.OP, index];
-    const outputRange = [1, 0, 0, 1];
+    this._isPartOfSharedTransition = getIsPartOfSharedTransition(this._getName(), this._route);
+    this._isPartOfTransition = getIsPartOfTransition(this._getName(), this._route);
+    this._isAnchored = getIsAnchored(this._getName(), this._route);
+    const shouldHideElement = this._isPartOfSharedTransition
+      || this._isPartOfTransition || this._isAnchored;
 
-    const isPartOfSharedTransition = getIsPartOfSharedTransition(this._getName(), this._route);
-    const isPartOfTransition = getIsPartOfTransition(this._getName(), this._route);
-    const isAnchored = getIsAnchored(this._getName(), this._route);
-    const visibilityProgress = progress.interpolate({ inputRange, outputRange });
+    const { shared } = this.props;
+    if (isOverlayChild && !shared) return { opacity: 0 };
+    if ((isOverlayChild && shouldHideElement) || shouldHideElement) {
+      const inputRange = [this._index - 1, (this._index - 1) + Constants.OP,
+        this._index - Constants.OP, this._index];
+      const outputRange = [1, 0, 0, 1];
 
-    if (isPartOfSharedTransition || isPartOfTransition || isAnchored) {
-      return { opacity: visibilityProgress };
+      return { opacity: progress.interpolate({ inputRange, outputRange }) };
     }
     return {};
   }

--- a/lib/TransitionView.js
+++ b/lib/TransitionView.js
@@ -198,8 +198,7 @@ class Transition extends React.Component<TransitionProps> {
       || this._isPartOfTransition || this._isAnchored;
 
     const { shared } = this.props;
-    if (isOverlayChild && !shared) return { opacity: 0 };
-    if ((isOverlayChild && shouldHideElement) || shouldHideElement) {
+    if ((isOverlayChild && !shared) || (isOverlayChild && shouldHideElement) || shouldHideElement) {
       const inputRange = [this._index - 1, (this._index - 1) + Constants.OP,
         this._index - Constants.OP, this._index];
       const outputRange = [1, 0, 0, 1];

--- a/lib/TransitionView.js
+++ b/lib/TransitionView.js
@@ -77,7 +77,9 @@ class Transition extends React.Component<TransitionProps> {
   _isAnchored: boolean;
 
   shouldComponentUpdate(nextProps) {
-    const { name, appear, disappear, shared, delay, animated, anchor, zIndex, top } = this.props;
+    const { name, appear, disappear, shared, delay, animated, anchor,
+      zIndex, top, parent } = this.props;
+
     if (name !== nextProps.name
       || appear !== nextProps.appear
       || disappear !== nextProps.disappear
@@ -86,7 +88,8 @@ class Transition extends React.Component<TransitionProps> {
       || animated !== nextProps.animated
       || anchor !== nextProps.anchor
       || zIndex !== nextProps.zIndex
-      || top !== nextProps.top) return true;
+      || top !== nextProps.top
+      || parent !== nextProps.parent) return true;
 
     const { getIndex, getIsAnchored, getIsPartOfSharedTransition,
       getIsPartOfTransition } = this.context;
@@ -110,7 +113,7 @@ class Transition extends React.Component<TransitionProps> {
   }
 
   componentWillMount() {
-    const { route, register, isOverlayChild } = this.context;
+    const { route, register, isOverlayChild, getParentTransition } = this.context;
     const { shared, appear, top, disappear, delay, zIndex, anchor, animated } = this.props;
     if (register) {
       this._route = route;
@@ -119,7 +122,7 @@ class Transition extends React.Component<TransitionProps> {
         register(new TransitionItem(
           this._getName(), route, this, shared !== undefined, appear,
           disappear, delay !== undefined, zIndex || _zIndex++, anchor, animated,
-          top,
+          top, (getParentTransition ? getParentTransition() : null),
         ));
       }
     }

--- a/lib/TransitionView.js
+++ b/lib/TransitionView.js
@@ -201,7 +201,9 @@ class Transition extends React.Component<TransitionProps> {
       || this._isPartOfTransition || this._isAnchored;
 
     const { shared } = this.props;
-    if ((isOverlayChild && !shared) || (isOverlayChild && shouldHideElement) || shouldHideElement) {
+    if ((isOverlayChild && !shared)
+      || (isOverlayChild && shouldHideElement)
+      || shouldHideElement) {
       const inputRange = [this._index - 1, (this._index - 1) + Constants.OP,
         this._index - Constants.OP, this._index];
       const outputRange = [1, 0, 0, 1];

--- a/lib/TransitionView.js
+++ b/lib/TransitionView.js
@@ -21,7 +21,7 @@ type TransitionProps = {
   innerRef: ?any,
   children: Array<any>,
   zIndex: Number,
-  top: ?boolean,
+  flat: ?boolean,
 }
 
 class Transition extends React.Component<TransitionProps> {
@@ -78,7 +78,7 @@ class Transition extends React.Component<TransitionProps> {
 
   shouldComponentUpdate(nextProps) {
     const { name, appear, disappear, shared, delay, animated, anchor,
-      zIndex, top, parent } = this.props;
+      zIndex, flat, parent } = this.props;
 
     if (name !== nextProps.name
       || appear !== nextProps.appear
@@ -88,7 +88,7 @@ class Transition extends React.Component<TransitionProps> {
       || animated !== nextProps.animated
       || anchor !== nextProps.anchor
       || zIndex !== nextProps.zIndex
-      || top !== nextProps.top
+      || flat !== nextProps.flat
       || parent !== nextProps.parent) return true;
 
     const { getIndex, getIsAnchored, getIsPartOfSharedTransition,
@@ -114,7 +114,7 @@ class Transition extends React.Component<TransitionProps> {
 
   componentWillMount() {
     const { route, register, isOverlayChild, getParentTransition } = this.context;
-    const { shared, appear, top, disappear, delay, zIndex, anchor, animated } = this.props;
+    const { shared, appear, flat, disappear, delay, zIndex, anchor, animated } = this.props;
     if (register) {
       this._route = route;
       if (!isOverlayChild) {
@@ -122,7 +122,7 @@ class Transition extends React.Component<TransitionProps> {
         register(new TransitionItem(
           this._getName(), route, this, shared !== undefined, appear,
           disappear, delay !== undefined, zIndex || _zIndex++, anchor, animated,
-          top, (getParentTransition ? getParentTransition() : null),
+          flat, (getParentTransition ? getParentTransition() : null),
         ));
       }
     }

--- a/lib/Transitions/TransitionTypes.js
+++ b/lib/Transitions/TransitionTypes.js
@@ -6,6 +6,7 @@ import { getRightTransition } from './getRightTransition';
 import { getHorizontalTransition } from './getHorizontalTransition';
 import { getVerticalTransition } from './getVerticalTransition';
 import { getFlipTransition } from './getFlipTransition';
+import { getFadeTransition } from './getFadeTransition';
 
 type TransitionEntry = {
   name: string,
@@ -23,6 +24,7 @@ export function initTransitionTypes() {
   registerTransitionType('horizontal', getHorizontalTransition);
   registerTransitionType('vertical', getVerticalTransition);
   registerTransitionType('flip', getFlipTransition);
+  registerTransitionType('fade', getFadeTransition);
   registerTransitionType('none', () => ({}));
 }
 

--- a/lib/Transitions/getFadeTransition.js
+++ b/lib/Transitions/getFadeTransition.js
@@ -7,14 +7,18 @@ export const getFadeTransition = (transitionSpecification: TransitionSpecificati
   const { start, end } = transitionSpecification;
   let startValue = 1;
   let endValue = 0;
+  let startIp = start;
+  let endIp = 0.05;
 
   if (transitionSpecification.direction === RouteDirection.to) {
     startValue = 0;
     endValue = 1;
+    endIp = end;
+    startIp = 0.95;
   }
 
   const progress = transitionSpecification.progress.interpolate({
-    inputRange: [0, start, end, 1],
+    inputRange: [0, startIp, endIp, 1],
     outputRange: [startValue, startValue, endValue, endValue],
   });
 

--- a/lib/Transitions/getFadeTransition.js
+++ b/lib/Transitions/getFadeTransition.js
@@ -7,18 +7,14 @@ export const getFadeTransition = (transitionSpecification: TransitionSpecificati
   const { start, end } = transitionSpecification;
   let startValue = 1;
   let endValue = 0;
-  let startIp = start;
-  let endIp = 0.05;
 
   if (transitionSpecification.direction === RouteDirection.to) {
     startValue = 0;
     endValue = 1;
-    endIp = end;
-    startIp = 0.95;
   }
 
   const progress = transitionSpecification.progress.interpolate({
-    inputRange: [0, startIp, endIp, 1],
+    inputRange: [0, start, end, 1],
     outputRange: [startValue, startValue, endValue, endValue],
   });
 

--- a/lib/Transitions/getFadeTransition.js
+++ b/lib/Transitions/getFadeTransition.js
@@ -1,0 +1,22 @@
+import { RouteDirection, TransitionSpecification } from '../Types';
+
+export const getFadeTransition = (transitionSpecification: TransitionSpecification) => {
+  if (!transitionSpecification || transitionSpecification.metrics === undefined) {
+    return {};
+  }
+  const { start, end } = transitionSpecification;
+  let startValue = 1;
+  let endValue = 0;
+
+  if (transitionSpecification.direction === RouteDirection.to) {
+    startValue = 0;
+    endValue = 1;
+  }
+
+  const progress = transitionSpecification.progress.interpolate({
+    inputRange: [0, start, end, 1],
+    outputRange: [startValue, startValue, endValue, endValue],
+  });
+
+  return { opacity: progress };
+};

--- a/lib/Transitions/getTransitionElements.js
+++ b/lib/Transitions/getTransitionElements.js
@@ -11,35 +11,45 @@ import {
   TransitionSpecification,
 } from '../Types';
 
-
 const getTransitionElements = (transitionElements: Array<TransitionItem>,
-  transitionContext: TransitionContext) => transitionElements.map((item, idx) => {
-  const routeDirection = transitionContext.getDirectionForRoute(item.name, item.route);
-  let element = React.Children.only(item.reactElement.props.children);
-  const key = `ti-${item.name}`;
+  transitionContext: TransitionContext) => {
+  const screenSize = Dimensions.get('window');
+  return transitionElements.map((item) => {
+    const routeDirection = transitionContext.getDirectionForRoute(item.name, item.route);
+    let element = React.Children.only(item.reactElement.props.children);
+    const key = `ti-${item.name}`;
 
-  const transitionStyle = getPositionStyle(
-    item, routeDirection === RouteDirection.from
-      ? transitionContext.delayCountFrom + 1 : transitionContext.delayCountTo + 1,
-    routeDirection === RouteDirection.from
-      ? transitionContext.delayIndexFrom : transitionContext.delayIndexTo,
-    transitionContext,
-  );
-
-  const style = [transitionStyle, styles.transitionElement];
-  const props = { ...element.props, __index: item.index };
-  element = React.createElement(element.type, { ...props, key });
-  const comp = createAnimatedWrapper({ component: element, nativeStyles: style });
-
-  if (item.delay) {
-    if (routeDirection === RouteDirection.from) {
-      transitionContext.delayIndexFrom += transitionContext.delayFromFactor;
-    } else {
-      transitionContext.delayIndexTo += transitionContext.delayToFactor;
+    // Check if we are on screen
+    if (item.boundingBoxMetrics.x > screenSize.width
+      || item.boundingBoxMetrics.x + item.boundingBoxMetrics.width < 0
+      || item.boundingBoxMetrics.y > screenSize.height
+      || item.boundingBoxMetrics.y + item.boundingBoxMetrics.height < 0) {
+      return null;
     }
-  }
-  return comp;
-});
+
+    const transitionStyle = getPositionStyle(
+      item, routeDirection === RouteDirection.from
+        ? transitionContext.delayCountFrom + 1 : transitionContext.delayCountTo + 1,
+      routeDirection === RouteDirection.from
+        ? transitionContext.delayIndexFrom : transitionContext.delayIndexTo,
+      transitionContext,
+    );
+
+    const style = [transitionStyle, styles.transitionElement];
+    const props = { ...element.props, __index: item.index };
+    element = React.createElement(element.type, { ...props, key });
+    const comp = createAnimatedWrapper({ component: element, nativeStyles: style });
+
+    if (item.delay) {
+      if (routeDirection === RouteDirection.from) {
+        transitionContext.delayIndexFrom += transitionContext.delayFromFactor;
+      } else {
+        transitionContext.delayIndexTo += transitionContext.delayToFactor;
+      }
+    }
+    return comp;
+  }).filter(p => p !== null);
+};
 
 const getPositionStyle = (item: TransitionItem, delayCount: number, delayIndex: number,
   transitionContext: TransitionContext) => {

--- a/lib/Transitions/getTransitionElements.js
+++ b/lib/Transitions/getTransitionElements.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
 
-import { createAnimatedWrapper } from '../Utils/createAnimatedWrapper';
+import { createAnimatedWrapper, getResolvedMetrics } from '../Utils';
 import { getTransitionType } from './TransitionTypes';
 import * as Constants from '../TransitionConstants';
 import TransitionItem from '../TransitionItem';
@@ -42,15 +42,16 @@ const getTransitionElements = (transitionElements: Array<TransitionItem>,
 });
 
 const getPositionStyle = (item: TransitionItem, delayCount: number, delayIndex: number,
-  transitionContext: TransitionContext) => ({
-  // borderWidth: 1,
-  // borderColor: '#00FFFF',
-  left: item.metrics.x,
-  top: item.metrics.y,
-  width: item.metrics.width,
-  height: item.metrics.height,
-  ...getTransitionStyle(item, delayCount, delayIndex, transitionContext),
-});
+  transitionContext: TransitionContext) => {
+  const resolvedMetrics = getResolvedMetrics(item, item.metrics);
+  return {
+    left: resolvedMetrics.x,
+    top: resolvedMetrics.y,
+    width: resolvedMetrics.width,
+    height: resolvedMetrics.height,
+    ...getTransitionStyle(item, delayCount, delayIndex, transitionContext),
+  };
+};
 
 const getTransitionStyle = (item: TransitionItem, delayCount: number, delayIndex: number,
   transitionContext: TransitionContext) => {
@@ -131,18 +132,7 @@ const getTransitionFunction = (item: TransitionItem, routeDirection: RouteDirect
 
 const styles = StyleSheet.create({
   transitionElement: {
-    // borderColor: '#00F',
-    // borderWidth: 1,
     position: 'absolute',
-    margin: 0,
-    marginVertical: 0,
-    marginHorizontal: 0,
-    marginTop: 0,
-    marginBottom: 0,
-    marginLeft: 0,
-    marginRight: 0,
-    marginStart: 0,
-    marginEnd: 0,
   },
 });
 

--- a/lib/Transitions/getTransitionElements.js
+++ b/lib/Transitions/getTransitionElements.js
@@ -16,7 +16,7 @@ const getTransitionElements = (transitionElements: Array<TransitionItem>,
   transitionContext: TransitionContext) => transitionElements.map((item, idx) => {
   const routeDirection = transitionContext.getDirectionForRoute(item.name, item.route);
   let element = React.Children.only(item.reactElement.props.children);
-  const key = `ti-${idx.toString()}`;
+  const key = `ti-${item.name}`;
 
   const transitionStyle = getPositionStyle(
     item, routeDirection === RouteDirection.from

--- a/lib/Transitions/getTransitionElements.js
+++ b/lib/Transitions/getTransitionElements.js
@@ -27,6 +27,11 @@ const getTransitionElements = (transitionElements: Array<TransitionItem>,
       return null;
     }
 
+    // Check if we are anchored
+    if (item.anchor) {
+      return null;
+    }
+
     const transitionStyle = getPositionStyle(
       item, routeDirection === RouteDirection.from
         ? transitionContext.delayCountFrom + 1 : transitionContext.delayCountTo + 1,

--- a/lib/Utils/createAnimatedWrapper.js
+++ b/lib/Utils/createAnimatedWrapper.js
@@ -131,21 +131,21 @@ const createAnimatedWrapper = (params: Parameters) => {
   );
 
   // if (__DEV__) {
-  //   if(params.log) {
-  //     const log = (params.logPrefix ? params.logPrefix + "\n" : "") +
-  //       "  innerElement:          " + JSON.stringify(StyleSheet.flatten(innerElement.props.style)) + "\n" +
-  //       "  animatedElement:       " + JSON.stringify(StyleSheet.flatten(animatedElement.props.style)) + "\n" +
-  //       "  nativeAnimatedElement: " + JSON.stringify(StyleSheet.flatten(nativeAnimatedElement.props.style));
-  //     if(lastLog !== log){
+  //   if (params.log) {
+  //     const log = `${params.logPrefix ? `${params.logPrefix}\n` : ''
+  //     }  innerElement:          ${JSON.stringify(StyleSheet.flatten(innerElement.props.style))}\n`
+  //       + `  animatedElement:       ${JSON.stringify(StyleSheet.flatten(animatedElement.props.style))}\n`
+  //       + `  nativeAnimatedElement: ${JSON.stringify(StyleSheet.flatten(nativeAnimatedElement.props.style))}`;
+  //     if (lastLog !== log) {
   //       lastLog = log;
-  //       console.log("\n" + log + "\n");
+  //       console.log(`\n${log}\n`);
   //     }
   //   }
   // }
 
   return nativeAnimatedElement;
 };
-// const lastLog = '';
+// let lastLog = '';
 
 const createAnimated = () => {
   // Create wrapped view
@@ -338,11 +338,20 @@ const positionStyles = [
   'maxHeight',
 ];
 
+const shadowStyles = [
+  'shadowColor',
+  'shadowOffset',
+  'shadowOpacity',
+  'shadowRadius',
+  'elevation',
+];
+
 const excludePropsForComponent = [
   ...paddingStyles,
   ...marginStyles,
   ...borderStyles,
   ...positionStyles,
+  ...shadowStyles,
   'display',
   // 'width',
   // 'height',
@@ -371,6 +380,7 @@ const excludePropsForComponent = [
 const includePropsForNativeStyles = [
   ...marginStyles,
   ...positionStyles,
+  ...shadowStyles,
   'display',
   'width',
   'height',
@@ -386,11 +396,6 @@ const includePropsForNativeStyles = [
   'zIndex',
   'direction',
   'transform',
-  'shadowColor',
-  'shadowOffset',
-  'shadowOpacity',
-  'shadowRadius',
-  'elevation',
 ];
 
 const excludePropsForStyles = [

--- a/lib/Utils/createAnimatedWrapper.js
+++ b/lib/Utils/createAnimatedWrapper.js
@@ -288,7 +288,7 @@ const paddingStyles = [
   'paddingEnd',
 ];
 
-const marginStyles = [
+const marginStyles = [
   'margin',
   'marginVertical',
   'marginHorizontal',

--- a/lib/Utils/createAnimatedWrapper.js
+++ b/lib/Utils/createAnimatedWrapper.js
@@ -318,6 +318,11 @@ const borderStyles = [
   'borderBottomStartRadius',
   'borderBottomEndRadius',
   'borderStyle',
+  'borderWidth',
+  'borderLeftWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderTopWidth',
 ];
 
 const positionStyles = [

--- a/lib/Utils/getResolvedMetrics.js
+++ b/lib/Utils/getResolvedMetrics.js
@@ -2,14 +2,14 @@ import { StyleSheet } from 'react-native';
 import TransitionItem from '../TransitionItem';
 
 export const getResolvedMetrics = (item: TransitionItem, metrics: any) => {
-  const style = item.getFlattenedStyle();
+  const style = item.getItemStyle();
   const margins = getMarginsFromStyle(style);
   if (margins) {
     return {
       x: metrics.x - margins.left,
       y: metrics.y - margins.top,
-      width: metrics.width, // - margins.right,
-      height: metrics.height, // - margins.bottom,
+      width: metrics.width,
+      height: metrics.height,
     };
   }
   return metrics;

--- a/lib/Utils/getResolvedMetrics.js
+++ b/lib/Utils/getResolvedMetrics.js
@@ -1,0 +1,44 @@
+import { StyleSheet } from 'react-native';
+import TransitionItem from '../TransitionItem';
+
+export const getResolvedMetrics = (item: TransitionItem, metrics: any) => {
+  const style = item.getFlattenedStyle();
+  const margins = getMarginsFromStyle(style);
+  if (margins) {
+    return {
+      x: metrics.x - margins.left,
+      y: metrics.y - margins.top,
+      width: metrics.width, // - margins.right,
+      height: metrics.height, // - margins.bottom,
+    };
+  }
+  return metrics;
+};
+
+const getMarginsFromStyle = (style: StyleSheet.Style) => {
+  const retVal = { left: 0, top: 0, bottom: 0, right: 0 };
+  if (!style) return retVal;
+  if (style.margin) {
+    retVal.left = style.margin;
+    retVal.top = style.margin;
+    retVal.right = style.margin;
+    retVal.bottom = style.margin;
+  }
+
+  if (style.marginHorizontal) {
+    retVal.left = style.marginHorizontal;
+    retVal.right = style.marginHorizontal;
+  }
+
+  if (style.marginVertical) {
+    retVal.top = style.marginVertical;
+    retVal.bottom = style.marginVertical;
+  }
+
+  if (style.marginTop) retVal.top = style.marginTop;
+  if (style.marginLeft) retVal.left = style.marginLeft;
+  if (style.marginRight) retVal.right = style.marginRight;
+  if (style.marginBottom) retVal.bottom = style.marginBottom;
+
+  return retVal;
+};

--- a/lib/Utils/index.js
+++ b/lib/Utils/index.js
@@ -2,3 +2,4 @@ export * from './createAnimatedWrapper';
 export * from './mergeStyles';
 export * from './getRotationFromStyle';
 export * from './rotation';
+export * from './getResolvedMetrics';


### PR DESCRIPTION
It is often necessary to support nested transitions. An example is a list of cards with images where the card itself should be transitioned to the background of the details screen, while the image should transitioned to a bigger version of the image. 

This PR also contains fixes for #72.