### PR TITLE
Make possible to get ref of Transition's inner element

### DIFF
--- a/lib/TransitionView.js
+++ b/lib/TransitionView.js
@@ -18,6 +18,7 @@ type TransitionProps = {
   delay: ?boolean,
   animated: ?string,
   anchor: ?string,
+  innerRef: ?any,
   children: Array<any>,
   zIndex: Number,
 }
@@ -98,7 +99,7 @@ class Transition extends React.Component<TransitionProps> {
   }
 
   render() {
-    const { children } = this.props;
+    const { children, innerRef } = this.props;
     let element = React.Children.only(children);
     if (!element) { return null; }
 
@@ -114,6 +115,7 @@ class Transition extends React.Component<TransitionProps> {
       nativeStyles: [visibilityStyle, styles.transition],
       nativeCached: this._outerAnimatedComponent,
       cached: this._animatedComponent,
+      innerRef,
       log: true,
       logPrefix: `TV ${this._getName()}/${this._route}`,
     });

--- a/lib/Utils/createAnimatedWrapper.js
+++ b/lib/Utils/createAnimatedWrapper.js
@@ -49,6 +49,7 @@ type Parameters = {
   nativeCached: ?any,
   cached: ?any,
   equalAspectRatio: ?boolean,
+  innerRef: ?any,
   log: ?Boolean,
   logPrefix: ?string
 }
@@ -71,6 +72,7 @@ const createAnimatedWrapper = (params: Parameters) => {
   // create inner element
   const innerElement = React.createElement(params.component.type, {
     ...params.component.props,
+    ref: params.innerRef,
     style: [componentStyles, getDebugBorder('#F00')],
   });
 


### PR DESCRIPTION
Now we can get ref of `Transition`'s inner element by introduced `innerRef` prop of `Transition`. Curretly `ref` of inner element just doesn't work.

```
<Transition innerRef={ref => (this.inputRef = ref)}>
    <TextInput />
</Transition>
```

@chrfalch We have to introduce extra `innerRef` prop to `Transition`. If there is a better way, please let me know so I'll reimplement.

Solution to #78 