### PR TITLE
Fixed error: In this environment the sources for assign MUST be an object. This error is a performance optimization and not spec compliant.

### DIFF
--- a/lib/TransitionItemsView.js
+++ b/lib/TransitionItemsView.js
@@ -116,7 +116,7 @@ export default class TransitionItemsView extends React.Component<
         ref={(ref) => this._viewRef = ref}
         collapsable={false}
       >
-        <ScreenContainer style={{ ...StyleSheet.absoluteFill }}>
+        <ScreenContainer style={{ ...StyleSheet.absoluteFillObject }}>
           {children}
         </ScreenContainer>
         <TransitionOverlayView


### PR DESCRIPTION
Getting exception at runtime: In this environment the sources for assign MUST be an object. This error is a performance optimization and not spec compliant.

Fixed wrong usage of StyleSheet.absoluteFill -> StyleSheet.absoluteFillObject in `TransitionItemsView` render. 

Closes #112 