### PR TITLE
Fix Invariant violation when using withNavigation HOC

### DIFF
--- a/lib/FluidTransitioner.js
+++ b/lib/FluidTransitioner.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Platform, Easing, I18nManager, Animated, PanResponder, InteractionManager } from 'react-native';
-import { NavigationActions, Transitioner } from 'react-navigation';
+import { NavigationActions, Transitioner, SceneView } from 'react-navigation';
 import clamp from 'clamp';
 
 import TransitionItemsView from './TransitionItemsView';
@@ -360,7 +360,6 @@ class FluidTransitioner extends React.Component<*> {
     const { scene, position } = transitionProps;
     const { index } = scene;
     const { navigation } = scene.descriptor;
-    const SceneView = scene.descriptor.getComponent();
     const { screenProps } = this.props;
     return (
       <TransitionRouteView
@@ -375,6 +374,7 @@ class FluidTransitioner extends React.Component<*> {
         <SceneView
           navigation={navigation}
           screenProps={screenProps}
+          component={scene.descriptor.getComponent()}
         />
       </TransitionRouteView>
     );


### PR DESCRIPTION
Inspired by this fix: https://github.com/react-navigation/react-navigation-drawer/commit/6c33d058ee9ae83711537fc53e9fe0f53be4162d

(Found via this comment https://github.com/react-navigation/react-navigation/issues/4416#issuecomment-395918538)

Fixes #92 


One use-case for the withNavigation HOC is the NavigationEvents component: https://reactnavigation.org/docs/en/navigation-events.html. Using this component with react-navigation-fluid-transitions triggers the error but works when this fix is applied