### PR TITLE
added getCustomActionCreator in stackRouterConfig

### DIFF
--- a/lib/createFluidNavigator.js
+++ b/lib/createFluidNavigator.js
@@ -24,6 +24,7 @@ export default (routeConfigMap, stackConfig = {}) => {
     initialRouteParams,
     paths,
     navigationOptions,
+    getCustomActionCreators,
   };
 
   class FluidNavigationView extends React.Component {


### PR DESCRIPTION
StackRouter provides supports for custom action creators which, I found out, are not provided by the FluidNavigator, so this PR fixes it.