### PR TITLE
Fixed issue with overlay not redrawing on navigating back.

### DIFF
--- a/lib/TransitionOverlayView.js
+++ b/lib/TransitionOverlayView.js
@@ -37,7 +37,7 @@ class TransitionOverlayView extends React.Component<Props> {
 
   _interpolation: any;
 
-  shouldComponentUpdate(nextProps: Props) {
+  /* shouldComponentUpdate(nextProps: Props) {
     const { direction, fromRoute, toRoute, index, sharedElements, transitionElements } = this.props;
     const seDiffers = !compareSharedElements(sharedElements, nextProps.sharedElements);
     const teDiffers = !compareTransitionElements(transitionElements, nextProps.transitionElements);
@@ -48,9 +48,8 @@ class TransitionOverlayView extends React.Component<Props> {
       || seDiffers || teDiffers) {
       return true;
     }
-
     return false;
-  }
+  }*/
 
   render() {
     const { fromRoute, toRoute } = this.props;


### PR DESCRIPTION
The overlay (which draws the shared elements while they are transitioning) had a performance optimization to avoid unnecessary redraws. This has been removed.

Fixes issue #105, #113 
