### PR TITLE
Upgrade the project to be compatible with react-navigation@3

### DIFF
--- a/lib/FluidTransitioner.js
+++ b/lib/FluidTransitioner.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Platform, Easing, I18nManager, Animated, PanResponder, InteractionManager } from 'react-native';
-import { NavigationActions, Transitioner, SceneView } from 'react-navigation';
+import { NavigationActions, SceneView } from 'react-navigation';
+import { Transitioner } from 'react-navigation-stack';
 import clamp from 'lodash.clamp';
 
 import TransitionItemsView from './TransitionItemsView';

--- a/lib/createFluidNavigator.js
+++ b/lib/createFluidNavigator.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   StackRouter,
-  createNavigationContainer,
   createNavigator,
   StackActions,
   getCustomActionCreators,

--- a/lib/createFluidNavigator.js
+++ b/lib/createFluidNavigator.js
@@ -58,6 +58,5 @@ export default (routeConfigMap, stackConfig = {}) => {
   }
 
   const router = StackRouter(routeConfigMap, stackRouterConfig);
-  const Navigator = createNavigator(FluidNavigationView, router, stackConfig);
-  return createNavigationContainer(Navigator);
+  return createNavigator(FluidNavigationView, router, stackConfig);
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-native": "0.56.0",
     "react-native-screens": "^1.0.0-alpha.12",
     "react-native-vector-icons": "^5.0.0",
-    "react-navigation": "2.16.0"
+    "react-navigation": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.40",


### PR DESCRIPTION
In react-navigation@3, ```createNavigationContainer``` is not necessary anymore. ```Transisioner``` should be imported from ```react-navigation-stack```.

This is a more completed merge request of #143 

This also tries to resolve #139, #137, #135 