### PR TITLE
Fix for the deprecated Transitioner import Issue #137

### DIFF
--- a/lib/FluidTransitioner.js
+++ b/lib/FluidTransitioner.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, Platform, Easing, I18nManager, Animated, PanResponder, InteractionManager } from 'react-native';
-import { NavigationActions, Transitioner, SceneView } from 'react-navigation';
+import { NavigationActions, SceneView } from 'react-navigation';
+import { Transitioner } from 'react-navigation-stack';
 import clamp from 'lodash.clamp';
 
 import TransitionItemsView from './TransitionItemsView';

--- a/lib/package.json
+++ b/lib/package.json
@@ -31,6 +31,7 @@
     "prop-types": "*"
   },
   "peerDependencies": {
+    "react-navigation-stack": "*",
     "react": "*",
     "react-native": "*",
     "react-navigation": "*",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
   },
   "dependencies": {
     "lodash.chunk": "^4.2.0",
-    "lodash.sortby": "^4.7.0",
     "lodash.clamp": "4.0.3",
+    "lodash.sortby": "^4.7.0",
     "prop-types": "^15.6.2",
     "react": "16.4.1",
     "react-native": "0.56.0",
     "react-native-screens": "^1.0.0-alpha.12",
     "react-native-vector-icons": "^5.0.0",
-    "react-navigation": "2.16.0"
+    "react-navigation": "2.16.0",
+    "react-navigation-stack": "^1.0.5"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5267,6 +5267,10 @@ react-navigation-stack@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-0.6.0.tgz#57dd25d0902137b950795549c43f3608e9edc250"
 
+react-navigation-stack@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-navigation-stack/-/react-navigation-stack-1.0.5.tgz#8aad306a069b080f32fcd48a11bfd6abfeb0a6b9"
+
 react-navigation-tabs@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/react-navigation-tabs/-/react-navigation-tabs-0.8.2.tgz#65f8a6ce368684227603345b4d312da2ef3366e1"


### PR DESCRIPTION
I tested that using the sample project the warning went away, seems to be okay. Had issues publishing it. If you have any contributor guide I'd be more than happy to follow.