### PR TITLE
registerInterpolatorType is not exported from InterpolatorTypes

### DIFF
--- a/lib/Interpolators/index.js
+++ b/lib/Interpolators/index.js
@@ -1,6 +1,6 @@
 export { 
   initInterpolatorTypes, 
-  registerInterpolatorType, 
+  registerInterpolator, 
   getInterpolatorTypes
 }
 from './InterpolatorTypes';


### PR DESCRIPTION
this doesn't seem to be used anywhere bedsides the `InterpolatorTypes` file itself so it seems like a safe fix