### PR TITLE
Fixes react-navigation@3.x.x change of router defaultNavigationOptions config

### DIFF
--- a/Examples/FlatList.js
+++ b/Examples/FlatList.js
@@ -144,7 +144,7 @@ const Navigator = FluidNavigator({
   list: { screen: ListScreen },
   details: { screen: DetailsScreen },
 }, {
-  navigationOptions: {
+  defaultNavigationOptions: {
     gesturesEnabled: true,
   },
 });

--- a/Examples/ImageTransition.js
+++ b/Examples/ImageTransition.js
@@ -174,7 +174,7 @@ const Navigator = FluidNavigator({
   imageList: { screen: ImageListScreen },
   imageDetails: { screen: ImageDetailsScreen },
 }, {
-  navigationOptions: {
+  defaultNavigationOptions: {
     gesturesEnabled: true,
   },
 });

--- a/Examples/Onboarding.js
+++ b/Examples/Onboarding.js
@@ -178,7 +178,7 @@ const Navigator = FluidNavigator({
   screen3: { screen: Screen3 },
 }, {
   mode: 'card',
-  navigationOptions: {
+  defaultNavigationOptions: {
     gesturesEnabled: true,
     gestureResponseDistance: {
       horizontal: Dimensions.get('window').width,

--- a/Examples/SharedElements.js
+++ b/Examples/SharedElements.js
@@ -163,7 +163,7 @@ const Navigator = createFluidNavigator({
   screen2: { screen: Screen2 },
   screen3: { screen: Screen3 },
 }, {
-  navigationOptions: { gesturesEnabled: true },
+  defaultNavigationOptions: { gesturesEnabled: false },
 });
 
 class SharedElements extends React.Component {

--- a/Examples/ShoeShop.js
+++ b/Examples/ShoeShop.js
@@ -187,7 +187,7 @@ const Navigator = FluidNavigator({
   screen2: { screen: Screen2 },
 }, {
   style: { backgroundColor: '#C14534' },
-  navigationOptions: {
+  defaultNavigationOptions: {
     gesturesEnabled: true,
   },
 });

--- a/docs/FluidNavigator.md
+++ b/docs/FluidNavigator.md
@@ -28,7 +28,7 @@ const Navigator = FluidNavigator({ Screens }, { transitionConfig });
 ```
 
 ## Gesture Support
-`FluidNavigator` supports gestures. To configure gesture support, add navigation options to the navigator or to individual screens:
+`FluidNavigator` supports gestures. To configure gesture support, add `defaultNavigationOptions` to the navigator or `navigationOptions` to individual screens:
 
 ```javascript
 const Navigator = FluidNavigator({
@@ -36,7 +36,7 @@ const Navigator = FluidNavigator({
   screen2: { screen: Screen2, navigationOptions: { gesturesEnabled: false } },
   screen3: { screen: Screen3 },
 }, {
-  navigationOptions: { gesturesEnabled: true },
+  defaultNavigationOptions: { gesturesEnabled: true },
 });
 ```
 

--- a/lib/createFluidNavigator.js
+++ b/lib/createFluidNavigator.js
@@ -4,7 +4,7 @@ import {
   createNavigator,
   StackActions,
   getCustomActionCreators,
-  defaultNavigationOptions,
+  defaultNavigationOptions as reactNavigationDefaultNavigationOptions,
 } from 'react-navigation';
 
 import FluidTransitioner from './FluidTransitioner';
@@ -16,16 +16,16 @@ export default (routeConfigMap, stackConfig = {}) => {
     paths,
     mode,
     transitionConfig,
-    navigationOptions,
+    defaultNavigationOptions,
     style,
   } = stackConfig;
 
   const stackRouterConfig = {
-    ...defaultNavigationOptions,
+    ...reactNavigationDefaultNavigationOptions,
     initialRouteName,
     initialRouteParams,
     paths,
-    navigationOptions,
+    defaultNavigationOptions,
     getCustomActionCreators,
   };
 


### PR DESCRIPTION
Found as a result of wanting to enable/disable gestures on a FluidNavigator: https://github.com/fram-x/FluidTransitions/issues/182

https://reactnavigation.org/blog/2018/11/17/react-navigation-3.0.html#renamed-navigationoptions-in-navigator-configuration