### PR TITLE
Add note for usage of native drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ myCustomTransitionFunction = (transitionInfo) => {
 
 Read more about the parameters and functionality for building [custom transitions](./docs/CustomTransition.md).
 
+### Native driver support
+For achieving the best experience it's vital to get rid of JS evaluation during animation run. React-native Animated API allows for scaling in both axis using native drivers, but it's not possible to resize width and height. Thus the native driver is used only when the ratio of source and target component are the same and it's recommended for the best quality of animations. 
+
 ### API
 
 [FluidNavigator](./docs/FluidNavigator.md)  

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ myCustomTransitionFunction = (transitionInfo) => {
 Read more about the parameters and functionality for building [custom transitions](./docs/CustomTransition.md).
 
 ### Native driver support
-For achieving the best experience it's vital to get rid of JS evaluation during animation run. React-native Animated API allows for scaling in both axis using native drivers, but it's not possible to resize width and height. Thus the native driver is used only when the ratio of source and target component are the same and it's recommended for the best quality of animations. 
+For achieving the best experience it's vital to get rid of JS evaluation during animation run. React-native Animated API allows for scaling in both axis using native drivers, but it's not possible to resize width and height (which calls for a layout computation). Thus the native driver is used only when the ratio of source and target component are the same and it's recommended for the best quality of animations. 
 
 ### API
 


### PR DESCRIPTION
I've observed that the quality of animations is changing depending on the fact if the ratio of source and target component is the same or not. I think it will be nice to put this note into docs. 