### PR TITLE
Remove undefined defaultNavigationOptions from createFluidNavigator

### DIFF
--- a/lib/createFluidNavigator.js
+++ b/lib/createFluidNavigator.js
@@ -4,7 +4,6 @@ import {
   createNavigator,
   StackActions,
   getCustomActionCreators,
-  defaultNavigationOptions as reactNavigationDefaultNavigationOptions,
 } from 'react-navigation';
 
 import FluidTransitioner from './FluidTransitioner';
@@ -21,7 +20,6 @@ export default (routeConfigMap, stackConfig = {}) => {
   } = stackConfig;
 
   const stackRouterConfig = {
-    ...reactNavigationDefaultNavigationOptions,
     initialRouteName,
     initialRouteParams,
     paths,


### PR DESCRIPTION
`defaultNavigationOptions` is not exported by `react-navigation`, what makes its usage ineffective in this context, since it will always be undefined.

@chrfalch, is there any underlying reason why we should keep this, or it's just a leftover? Tks.