### PR TITLE
rtl support in shared elements

### DIFF
--- a/lib/Interpolators/getSharedElements.js
+++ b/lib/Interpolators/getSharedElements.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dimensions } from 'react-native';
+import { Dimensions, I18nManager } from 'react-native';
 
 import TransitionItem from '../TransitionItem';
 import { createAnimatedWrapper, getResolvedMetrics, mergeStyles } from '../Utils';
@@ -24,7 +24,7 @@ const getSharedElements = (sharedElements: Array<any>,
 
   const overrideStyles = {
     position: 'absolute',
-    left: resolvedMetrics.x,
+    [I18nManager.isRTL ? "right" : "left"]: resolvedMetrics.x,
     top: resolvedMetrics.y,
     width: resolvedMetrics.width,
     height: resolvedMetrics.height,


### PR DESCRIPTION
This will fix the jumping element while transitioning in RTL, closes #203.
There is another file named `getAnchoredElements.js` with similar code, should this fix apply to that file too? how can I test it?

P.S the `anchor` props works fine no need to change  `getAnchoredElements.js` 