### PR TITLE
Fix require cycle in TransitionItem.js

### DIFF
--- a/lib/TransitionItem.js
+++ b/lib/TransitionItem.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { StyleSheet, Platform } from 'react-native';
-import ShallowRenderer from './Utils/shallowRenderer';
 import { Metrics } from './Types/Metrics';
-import { getRotationFromStyle, getBoundingBox, getOriginalRect } from './Utils';
+import ShallowRenderer from './Utils/shallowRenderer';
+import { getRotationFromStyle } from './Utils/getRotationFromStyle';
+import { getBoundingBox, getOriginalRect } from './Utils/rotation';
 
 type Size = {
   x: number,


### PR DESCRIPTION
Minor fix for https://github.com/fram-x/FluidTransitions/issues/175. This should fix the require cycle warning below when installing the package, by bypassing `Utils/index.js`:

```
require.js:114 Require cycle: 
node_modules/react-navigation-fluid-transitions/TransitionItem.js 
-> node_modules/react-navigation-fluid-transitions/Utils/index.js 
-> node_modules/react-navigation-fluid-transitions/Utils/getResolvedMetrics.js 
-> node_modules/react-navigation-fluid-transitions/TransitionItem.js

Require cycles are allowed, but can result in uninitialized values. 
Consider refactoring to remove the need for a cycle.
```
